### PR TITLE
Add C atomic operation 4

### DIFF
--- a/_posts/2024-06-06-tech-pjt-service-discovery.md
+++ b/_posts/2024-06-06-tech-pjt-service-discovery.md
@@ -393,8 +393,8 @@ public class DiscoveryService {
 - spring-cloud-commons 라이브러리에서 제공하는 `DiscoveryClient` 객체를 활용하여 Service Discovery에서 가져온 instance 정보들을 가지옵니다.
 
 
-<img src="https://github.com/valor-lee/valor-lee.github.io/assets/109330610/7a98763c-b8d1-4f1c-8e82-c1efc91344c2" width="400px" height="150px" title="Github_Logo"></img>
-<img src="https://github.com/valor-lee/valor-lee.github.io/assets/109330610/b09048bf-c8cd-44c5-9ccf-a2910d74e336" width="400px" height="150px" title="Github_Logo"></img>
+<img src="https://github.com/valor-lee/valor-lee.github.io/assets/109330610/7a98763c-b8d1-4f1c-8e82-c1efc91344c2" width="400px" height="150px" title="Github_Logo" alt="img1"></img>
+<img src="https://github.com/valor-lee/valor-lee.github.io/assets/109330610/b09048bf-c8cd-44c5-9ccf-a2910d74e336" width="400px" height="150px" title="Github_Logo" alt="img2"></img>
 
 - 이제 각 프로젝트를 실행하여 postman으로 테스트해보면 위와 같이 각 instance정보가 잘 조회됨을 확인할 수 있습니다.
 

--- a/_posts/2024-10-28-deep-learning-terms.md
+++ b/_posts/2024-10-28-deep-learning-terms.md
@@ -246,7 +246,7 @@ RNN에서 유용합니다.
 ReLU 함수 또는 ReLU의 변형 함수들을 활성화 함수로 사용할 경우에는 성능이 좋지 않습니다.
 
 
-[관련 논문](http://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf)
+[관련 논문](https://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf)
 
 
 ## He 초기화(He initializtion)
@@ -345,7 +345,7 @@ Subclassing API는 밑바닥부터 새로운 수준의 아키텍처를 구현해
 
 email 텍스트 데이터를 기반으로 레이블로 나누는 MLP 개발 과정을 볼 수 있습니다.
 
-[참고]([wikidocs](https://wikidocs.net/49071))
+[참고](https://wikidocs.net/49071)
 
 # 피드 포워드 신경망 언어 모델(Feed Forward Neural Network Language Model, FFNNLM)
 

--- a/_posts/2026-06-26-c-atomic-operation-4.md
+++ b/_posts/2026-06-26-c-atomic-operation-4.md
@@ -1,0 +1,1386 @@
+---
+title: '[C언어] Atomic Operation 4. Memory Order 이해하기'
+date: 2026-06-26 00:30:00 +09:00
+categories: [Language, C]
+tags:
+  [
+    C,
+    atomic,
+    memory order,
+    acquire release,
+    happens-before
+  ]
+---
+
+# 개요
+
+이전 글에서는 C의 atomic operation이 compiler와 CPU에서 어떻게 구현되는지 살펴봤다.
+
+하지만 atomic 연산을 사용할 때는 연산 자체가 나뉘지 않는다는 것만으로 충분하지 않을 수 있다.
+
+다음처럼 한 thread가 데이터를 준비하고, 다른 thread가 준비 완료 여부를 확인하는 상황을 생각해보자.
+
+```c
+int data = 0;
+atomic_bool ready = false;
+
+// Thread A
+data = 42;
+atomic_store(&ready, true);
+
+// Thread B
+if (atomic_load(&ready)) {
+    printf("data = %d\n", data);
+}
+```
+
+`ready`의 load와 store는 atomic하다.
+
+그렇다면 Thread B가 `true`를 읽었을 때 `data == 42`도 보장될까?
+
+이 질문에 답하려면 atomicity와 memory ordering을 구분해야 한다.
+
+이번 글에서는 다음 내용을 중심으로 C의 memory order를 정리한다.
+
+```text
+1. atomicity와 ordering의 차이
+2. happens-before와 synchronizes-with
+3. memory_order_relaxed
+4. memory_order_release와 memory_order_acquire
+5. memory_order_acq_rel
+6. memory_order_seq_cst
+7. memory_order_consume과 fence
+8. 연산별로 사용할 수 있는 memory order
+```
+
+글 전체의 핵심은 다음과 같다.
+
+```text
+Atomicity
+    -> 해당 atomic 객체의 연산이 중간에 찢어지지 않게 한다.
+
+Memory ordering
+    -> 그 atomic 연산의 앞뒤에 있는 다른 memory 접근이
+       thread 사이에서 어떤 순서로 관찰되는지를 정한다.
+```
+
+# 1. Atomicity와 ordering의 차이
+
+## 1.1 Atomicity의 범위
+
+atomic 연산은 해당 atomic 객체에 대한 접근을 안전하게 만든다.
+
+```c
+atomic_int counter = 0;
+
+atomic_fetch_add_explicit(&counter, 1, memory_order_relaxed);
+```
+
+여러 thread가 이 코드를 동시에 실행해도 `counter`의 증가는 lost update 없이 처리된다.
+
+여기서 `memory_order_relaxed`를 사용해도 read-modify-write 자체의 atomicity는 유지된다.
+
+즉 memory order를 약하게 지정한다고 atomic 연산이 일반 연산으로 바뀌는 것은 아니다.
+
+## 1.2 Ordering의 범위
+
+문제는 atomic 객체 주변에 일반 변수가 함께 있을 때다.
+
+```c
+int data = 0;
+atomic_bool ready = false;
+```
+
+Thread A는 `data`를 쓴 뒤 `ready`를 변경하고, Thread B는 `ready`를 확인한 뒤 `data`를 읽는다.
+
+```text
+Thread A                         Thread B
+
+data = 42                       ready 읽기
+ready = true                    data 읽기
+```
+
+우리가 원하는 의미는 다음과 같다.
+
+```text
+Thread B가 ready == true를 관찰했다면
+Thread A가 그 전에 수행한 data = 42도 관찰해야 한다.
+```
+
+이 관계는 `ready`가 atomic이라는 사실만으로 자동으로 만들어지지 않는다.
+
+두 thread 사이에 적절한 memory ordering이 필요하다.
+
+# 2. Happens-before 관계
+
+## 2.1 관계의 종류와 범위
+
+C memory model의 관계를 이해할 때는 각 관계가 어디까지 연결되는지 먼저 구분해야 한다.
+
+| 관계 | 적용 범위 | 의미 |
+|---|---|---|
+| `sequenced-before` | 하나의 thread 내부 | C abstract machine에서 두 평가의 순서를 나타낸다. |
+| `modification order` | 하나의 atomic 객체 | 해당 객체에 수행된 모든 modification의 일관된 순서를 나타낸다. |
+| `reads-from` | 특정 store와 load | load가 어느 store의 값을 읽었는지 나타낸다. |
+| `synchronizes-with` | 서로 다른 thread | release와 acquire 같은 synchronization operation을 연결한다. |
+| `happens-before` | thread 내부와 thread 사이 | sequenced-before와 synchronizes-with 등을 전이적으로 연결한 논리적 선후 관계다. |
+
+`reads-from`은 load가 어느 store의 값을 읽었는지 설명하기 위해 이 글에서 사용하는 표현이다.
+
+중요한 점은 `reads-from` 자체가 synchronization을 의미하지 않는다는 것이다.
+
+```text
+relaxed store  ------ reads-from ------>  relaxed load
+
+synchronizes-with 관계는 만들어지지 않음
+```
+
+반면 acquire load가 대응하는 release store의 값을 읽으면 synchronizes-with가 만들어진다.
+
+```text
+release store  ---- synchronizes-with ---->  acquire load
+```
+
+각 관계의 역할을 짧게 정리하면 다음과 같다.
+
+```text
+sequenced-before
+    -> 같은 thread 안의 언어상 순서
+
+modification order
+    -> atomic 객체 하나의 변경 순서
+
+reads-from
+    -> load가 어떤 store의 값을 읽었는지 나타내는 연결
+
+synchronizes-with
+    -> synchronization operation이 만드는 thread 사이의 연결
+
+happens-before
+    -> sequenced-before와 synchronizes-with 등을 연결해 도출하는 선후 관계
+```
+
+따라서 다음 두 상황은 서로 다르다.
+
+```text
+relaxed load가 relaxed store의 값을 읽음
+    -> reads-from 관계는 존재
+    -> synchronizes-with는 없음
+
+acquire load가 release store의 값을 읽음
+    -> reads-from 관계가 존재
+    -> synchronizes-with도 존재
+```
+
+## 2.2 Thread 내부의 언어 순서
+
+먼저 같은 thread 안에서 앞의 평가가 뒤의 평가보다 먼저 순서 지어져 있으면 `sequenced-before` 관계가 있다.
+
+```c
+data = 42;  // (1)
+atomic_store_explicit(&ready, true, memory_order_release);  // (2)
+```
+
+이 코드에서는 `(1)`이 `(2)`보다 sequenced-before다.
+
+```text
+data = 42
+    |
+    | sequenced-before
+    v
+release store: ready = true
+```
+
+여기서 sequenced-before는 CPU가 반드시 두 명령을 이 순서대로 실행한다는 뜻이 아니다.
+
+sequenced-before는 C abstract machine에서 두 평가 사이에 정의되는 **언어 수준의 관계**다.
+
+```text
+sequenced-before
+    != 실제 CPU 명령의 실행 순서
+    != 다른 core가 두 연산을 관찰하는 순서
+```
+
+compiler는 C memory model에서 허용되는 결과를 바꾸지 않는 범위에서 명령을 재배치할 수 있다.
+
+CPU 역시 out-of-order execution과 store buffer 등을 사용할 수 있다.
+
+따라서 소스 코드에 sequenced-before가 있더라도, 그 관계가 항상 같은 기계 명령 순서나 다른 core의 관찰 순서로 나타나는 것은 아니다.
+
+sequenced-before는 한 thread 안의 관계만 설명한다.
+
+Thread A의 연산과 Thread B의 연산을 연결하려면 thread 사이의 동기화 관계가 필요하다.
+
+## 2.3 Thread 사이의 동기화
+
+Thread A가 `release store`로 값을 저장하고 Thread B의 `acquire load`가 그 값을 읽으면, 두 atomic 연산 사이에 `synchronizes-with` 관계가 만들어진다.
+
+```c
+// Thread A
+data = 42;
+atomic_store_explicit(&ready, true, memory_order_release);
+
+// Thread B
+if (atomic_load_explicit(&ready, memory_order_acquire)) {
+    printf("data = %d\n", data);
+}
+```
+
+관계를 그림으로 나타내면 다음과 같다.
+
+```text
+Thread A                                      Thread B
+
+data = 42
+    |
+    | sequenced-before
+    v
+release store: ready = true  ---------------->  acquire load: ready
+                              synchronizes-with         |
+                                                        | sequenced-before
+                                                        v
+                                                    data 읽기
+
+data 쓰기  ---------------------------------------->  data 읽기
+                          happens-before
+```
+
+Thread A의 `data = 42`는 release store보다 sequenced-before다.
+
+release store는 그 값을 읽은 acquire load와 동기화된다.
+
+acquire load 뒤에는 Thread B의 `data` 읽기가 있다.
+
+이 관계들을 연결하면 Thread A의 `data` 쓰기가 Thread B의 `data` 읽기보다 happens-before가 된다.
+
+따라서 Thread B가 `ready == true`를 읽은 경로에서는 `data`를 안전하게 읽을 수 있고 `42`를 관찰한다.
+
+중요한 조건은 acquire load가 release store가 저장한 값을 실제로 읽어야 한다는 점이다.
+
+`ready == false`를 읽었다면 이 release와 acquire 사이에는 위와 같은 동기화가 만들어지지 않는다.
+
+# 3. Relaxed ordering
+
+## 3.1 단일 객체의 atomicity
+
+`memory_order_relaxed`는 가장 약한 memory order다.
+
+```c
+atomic_fetch_add_explicit(&counter, 1, memory_order_relaxed);
+```
+
+relaxed 연산도 다음 보장은 유지한다.
+
+```text
+해당 atomic 객체에 대한 연산은 atomic하다.
+해당 atomic 객체의 modification order를 따른다.
+```
+
+하나의 atomic 객체에 수행된 모든 변경에는 그 객체만의 일관된 modification order가 존재한다.
+
+예를 들어 여러 thread가 relaxed `fetch_add`를 수행해도 각 증가는 하나씩 순서가 정해지고 최종 counter 값도 올바르게 누적된다.
+
+## 3.2 언어 순서와 관찰 순서
+
+relaxed를 이해할 때 가장 헷갈리기 쉬운 지점은 sequenced-before와 실제 관찰 순서의 차이다.
+
+먼저 data race 없이 가능한 결과를 분석하기 위해 `data`와 `ready`를 모두 atomic으로 선언해보자.
+
+```c
+atomic_int data = 0;
+atomic_bool ready = false;
+
+// Thread A
+atomic_store_explicit(&data, 42, memory_order_relaxed);   // A1
+atomic_store_explicit(&ready, true, memory_order_relaxed); // A2
+
+// Thread B
+bool r1 = atomic_load_explicit(&ready, memory_order_relaxed);
+int r2 = atomic_load_explicit(&data, memory_order_relaxed);
+```
+
+Thread A 안에서는 `A1`이 `A2`보다 sequenced-before다.
+
+Thread B 안에서도 `ready`의 load가 `data`의 load보다 sequenced-before다.
+
+```text
+Thread A                              Thread B
+
+data.store(42)                        ready.load()
+    |                                      |
+    | sequenced-before                     | sequenced-before
+    v                                      v
+ready.store(true)                     data.load()
+```
+
+Thread B의 `ready` load가 Thread A의 `ready.store(true)` 값을 읽었다고 가정해보자.
+
+두 연산 사이에는 reads-from 관계가 있지만, 둘 다 relaxed이므로 synchronizes-with는 만들어지지 않는다.
+
+```text
+A1: data.store(42)
+    |
+    | sequenced-before
+    v
+A2: ready.store(true)  ------ reads-from ------>  B1: ready.load()
+                                                    |
+                         synchronizes-with 없음    | sequenced-before
+                                                    v
+                                                B2: data.load()
+```
+
+따라서 `A1 -> A2`의 sequenced-before 관계를 `B1 -> B2`까지 이어주는 thread 간 연결이 없다.
+
+따라서 다음 결과가 허용될 수 있다.
+
+```text
+r1 == true
+r2 == 0
+```
+
+소스 코드에는 `data.store(42)` 다음에 `ready.store(true)`가 있다.
+
+그런데도 compiler가 허용되는 범위에서 주변 연산을 재배치하거나, 약한 memory model의 CPU에서 서로 다른 주소의 store가 다른 core에 서로 다른 순서로 관찰될 수 있다.
+
+```text
+Thread A의 소스 코드 순서          Thread B의 관찰 결과
+
+data = 42                          ready == true
+ready = true                       data == 0
+```
+
+하드웨어 관점에서는 Thread A의 store가 store buffer와 cache coherence를 거쳐 다른 core에 전달된다.
+
+이때 Thread B가 Thread A의 store buffer를 직접 읽는 것은 아니다.
+
+Thread B는 `ready == true`를 관찰했지만 `data == 42`가 아직 자신에게 관찰 가능한 상태가 아니어서 `data`의 이전 값을 읽을 수 있다.
+
+relaxed에는 서로 다른 atomic 객체의 관찰 순서를 연결하는 barrier가 없기 때문이다.
+
+```text
+data의 modification order     0 -> 42
+ready의 modification order    false -> true
+
+두 modification order를 연결하는 thread 간 순서     없음
+```
+
+특정 x86-64 환경에서는 강한 hardware ordering과 compiler의 명령 선택 때문에 이 결과가 실제로 나타나지 않을 수 있다.
+
+하지만 그것이 relaxed에 이식 가능한 thread 간 순서 보장이 있다는 뜻은 아니다.
+
+즉 relaxed에서 sequenced-before가 사라지는 것이 아니다.
+
+```text
+sequenced-before는 언어 모델상 존재한다.
+실제 명령이 반드시 그 순서로 실행되어야 하는 것은 아니다.
+다른 core가 반드시 그 순서로 관찰해야 하는 것도 아니다.
+```
+
+## 3.3 Thread 동기화의 부재
+
+relaxed 연산은 다른 memory 접근을 thread 사이에서 동기화하지 않는다.
+
+앞의 publication 예제를 relaxed로 바꾸면 문제가 생긴다.
+
+```c
+int data = 0;
+atomic_bool ready = false;
+
+// Thread A
+data = 42;
+atomic_store_explicit(&ready, true, memory_order_relaxed);
+
+// Thread B
+if (atomic_load_explicit(&ready, memory_order_relaxed)) {
+    printf("data = %d\n", data);
+}
+```
+
+`ready`의 접근 자체는 안전하다.
+
+하지만 relaxed store와 relaxed load는 `data`의 write와 read 사이에 happens-before 관계를 만들지 않는다.
+
+```text
+Thread A                                  Thread B
+
+data = 42                                relaxed load: ready
+    |                                           |
+    | sequenced-before                          | sequenced-before
+    v                                           v
+relaxed store: ready = true              data 읽기
+
+             thread 사이를 잇는 동기화가 없음
+```
+
+따라서 Thread B가 `ready == true`를 읽더라도 일반 변수 `data`에 대한 접근은 C memory model에서 안전하게 동기화되지 않는다.
+
+Thread B가 `ready == true`인 분기로 들어가 `data`를 읽으면, Thread A의 write와 Thread B의 read는 서로 충돌하는 접근이면서 happens-before로 정렬되지 않는다.
+
+이 예제는 앞에서 모든 값을 atomic으로 선언한 예제보다 더 위험하다.
+
+모든 값을 atomic으로 선언한 예제에서는 `ready == true`, `data == 0`이 허용 가능한 atomic 관찰 결과다.
+
+여기서는 `data`가 일반 변수이므로 Thread A의 write와 Thread B의 read 사이에 data race가 발생해 프로그램 전체가 undefined behavior가 된다.
+
+특정 x86-64 환경에서 항상 `42`가 출력되더라도 올바른 C 프로그램이라는 뜻은 아니다.
+
+## 3.4 독립적인 통계 값
+
+relaxed는 다른 데이터를 보호할 필요가 없는 독립적인 값에 잘 맞는다.
+
+```c
+atomic_ulong request_count = 0;
+
+void record_request(void) {
+    atomic_fetch_add_explicit(
+        &request_count,
+        1,
+        memory_order_relaxed
+    );
+}
+```
+
+여기서 필요한 조건이 다음과 같다고 해보자.
+
+```text
+증가 연산이 유실되지 않아야 한다.
+조회 시점까지 반영된 대략적인 통계 값을 읽으면 된다.
+counter를 이용해 다른 데이터의 공개 여부를 판단하지 않는다.
+```
+
+이 경우에는 atomicity만 필요하므로 relaxed가 적절할 수 있다.
+
+```c
+unsigned long current_request_count(void) {
+    return atomic_load_explicit(
+        &request_count,
+        memory_order_relaxed
+    );
+}
+```
+
+반대로 counter의 특정 값을 보고 다른 객체의 초기화 완료 여부를 판단한다면 단순한 relaxed counter 문제가 아니다.
+
+# 4. Release와 acquire
+
+## 4.1 Release store
+
+`memory_order_release`는 주로 atomic store에 사용한다.
+
+```c
+data = 42;
+atomic_store_explicit(&ready, true, memory_order_release);
+```
+
+release는 이 연산보다 앞에 있는 memory 접근을 다른 thread에 공개하는 경계 역할을 한다.
+
+개념적으로는 앞의 연산이 release 뒤로 넘어가 동기화 의미를 깨뜨리지 못하게 한다.
+
+```text
+공개할 데이터 쓰기
+공개할 데이터 쓰기
+-------------------- release
+ready = true
+```
+
+release store 하나만으로 다른 thread가 데이터를 획득하는 것은 아니다.
+
+반대편에서 같은 atomic 객체를 적절한 acquire 연산으로 읽어야 한다.
+
+## 4.2 Acquire load
+
+`memory_order_acquire`는 주로 atomic load에 사용한다.
+
+```c
+if (atomic_load_explicit(&ready, memory_order_acquire)) {
+    use(data);
+}
+```
+
+acquire는 이 연산보다 뒤에 있는 memory 접근이 동기화 의미를 깨뜨리며 앞으로 넘어가지 못하게 하는 경계 역할을 한다.
+
+```text
+ready 읽기
+-------------------- acquire
+공개된 데이터 읽기
+공개된 데이터 읽기
+```
+
+acquire load가 대응하는 release store의 값을 읽으면 release 이전의 작업을 acquire 이후에서 관찰할 수 있다.
+
+이를 짧게 표현하면 다음과 같다.
+
+```text
+release: 이전 작업을 내보낸다.
+acquire: 공개된 작업을 받아들인다.
+```
+
+다만 release와 acquire가 모든 thread를 한 번에 멈추게 하는 전역 장벽이라는 뜻은 아니다.
+
+동기화는 어떤 atomic 연산이 어떤 값을 읽었는지에 따라 형성된다.
+
+## 4.3 데이터 publication
+
+release와 acquire의 대표적인 활용은 초기화한 데이터를 다른 thread에 공개하는 것이다.
+
+여기서 publication은 한 thread가 만든 데이터의 사용 권한을 다른 thread에 넘기는 패턴을 뜻한다.
+
+```text
+Producer
+    데이터 생성과 초기화
+    release store로 준비 완료를 알림
+
+Consumer
+    acquire load로 준비 완료를 확인
+    초기화된 데이터 사용
+```
+
+atomic flag가 실제 데이터를 운반하는 것은 아니다.
+
+데이터는 원래의 memory 위치에 있고, flag는 producer의 작업과 consumer의 작업을 연결하는 synchronization 지점으로 사용된다.
+
+### Publication 코드
+
+```c
+#include <stdatomic.h>
+#include <stdbool.h>
+
+typedef struct {
+    int id;
+    int price;
+    int quantity;
+} Order;
+
+Order shared_order;
+atomic_bool order_ready = false;
+
+void publish_order(void) {
+    shared_order.id = 1001;        // P1
+    shared_order.price = 72000;    // P2
+    shared_order.quantity = 3;     // P3
+
+    atomic_store_explicit(
+        &order_ready,
+        true,
+        memory_order_release
+    );                             // P4
+}
+
+bool try_read_order(Order* output) {
+    if (!atomic_load_explicit(
+            &order_ready,
+            memory_order_acquire)) { // C1
+        return false;
+    }
+
+    *output = shared_order;          // C2
+    return true;
+}
+```
+
+`shared_order`는 atomic 객체가 아니다.
+
+그런데도 이 코드가 안전할 수 있는 이유는 `order_ready`의 release/acquire가 일반 변수 접근 사이에 happens-before를 만들기 때문이다.
+
+### Producer의 release
+
+`publish_order`는 먼저 `shared_order`의 field를 초기화한다.
+
+```text
+P1: shared_order.id 쓰기
+P2: shared_order.price 쓰기
+P3: shared_order.quantity 쓰기
+P4: order_ready에 true를 release store
+```
+
+같은 thread 안에서 P1, P2, P3는 P4보다 sequenced-before다.
+
+```text
+P1, P2, P3
+     |
+     | sequenced-before
+     v
+P4: release store
+```
+
+P4는 "이 flag만 true로 바꾼다"는 의미에 그치지 않는다.
+
+P4 이전에 수행한 `shared_order`의 초기화를 acquire하는 consumer와 연결할 수 있는 publication 지점이 된다.
+
+release store만 실행했다고 모든 consumer가 즉시 데이터를 읽을 수 있게 되는 것은 아니다.
+
+consumer가 P4가 저장한 `true`를 acquire load로 읽어야 동기화가 완성된다.
+
+### Consumer의 acquire
+
+`try_read_order`는 먼저 C1에서 `order_ready`를 읽는다.
+
+```text
+C1이 false를 읽음
+    -> 아직 publication을 확인하지 못함
+    -> shared_order를 읽지 않고 반환
+
+C1이 P4의 true를 읽음
+    -> P4 synchronizes-with C1
+    -> C1 이후에 shared_order를 읽을 수 있음
+```
+
+이 예제에서는 `order_ready`를 `true`로 저장하는 thread가 producer 하나뿐이다.
+
+따라서 C1이 `true`를 읽었다면 P4가 저장한 값을 읽은 것으로 판단할 수 있다.
+
+그 결과 다음 관계가 형성된다.
+
+```text
+Producer                                      Consumer
+
+P1, P2, P3: shared_order 초기화
+       |
+       | sequenced-before
+       v
+P4: release store  ---------------------->  C1: acquire load
+                       synchronizes-with             |
+                                                     | sequenced-before
+                                                     v
+                                                C2: shared_order 복사
+```
+
+관계를 하나의 경로로 이어보면 다음과 같다.
+
+```text
+shared_order 초기화
+    sequenced-before
+release store
+    synchronizes-with
+acquire load
+    sequenced-before
+shared_order 복사
+```
+
+따라서 P1, P2, P3는 C2보다 happens-before다.
+
+```text
+P1, P2, P3  -------- happens-before -------->  C2
+```
+
+consumer가 `shared_order`를 읽을 때 producer의 초기화와 충돌하는 정렬되지 않은 접근이 남지 않는다.
+
+그래서 `shared_order`가 일반 non-atomic 객체여도 이 publication 경로에서는 data race가 발생하지 않는다.
+
+### Relaxed flag의 차이
+
+flag를 relaxed로 바꾸면 flag 자체의 load와 store는 여전히 atomic하다.
+
+```c
+// Producer
+shared_order.id = 1001;
+atomic_store_explicit(
+    &order_ready,
+    true,
+    memory_order_relaxed
+);
+
+// Consumer
+if (atomic_load_explicit(
+        &order_ready,
+        memory_order_relaxed)) {
+    use(shared_order.id);
+}
+```
+
+하지만 relaxed store와 relaxed load 사이에는 synchronizes-with가 만들어지지 않는다.
+
+```text
+shared_order 쓰기
+    sequenced-before
+relaxed store  -------- reads-from -------->  relaxed load
+                         synchronizes-with 없음        |
+                                                        | sequenced-before
+                                                        v
+                                                   shared_order 읽기
+```
+
+producer의 일반 write에서 consumer의 일반 read까지 이어지는 happens-before가 없으므로 `shared_order`에는 data race가 발생한다.
+
+이는 단순히 consumer가 예전 값을 읽을 수 있다는 수준이 아니라 C에서 undefined behavior다.
+
+### 하드웨어의 ordering
+
+release/acquire는 `shared_order`를 flag 안으로 복사하거나 cache 전체를 main memory로 flush하지 않는다.
+
+대신 compiler와 CPU가 다음 결과를 허용하지 않도록 필요한 ordering을 구현한다.
+
+```text
+Consumer가 order_ready == true를 확인함
+그런데 shared_order의 초기화 이전 값을 읽음
+```
+
+CPU는 store buffer와 cache coherence를 계속 사용한다.
+
+다만 acquire load가 release store의 값을 관찰한 경우, consumer가 release 이전의 write를 관찰할 수 있도록 명령 재배치와 memory 접근 순서를 제한한다.
+
+어떤 target에서는 release/acquire 전용 명령을 사용하고, 어떤 target에서는 기본 load/store만으로 필요한 ordering을 만족할 수 있다.
+
+중요한 것은 특정 cache를 비웠는지가 아니라 C memory model에서 요구한 관찰 결과가 보장되는지다.
+
+### Publication의 안전 조건
+
+이 예제는 다음 조건에서 안전하다.
+
+```text
+1. Producer가 shared_order를 모두 초기화한 뒤 release store를 수행한다.
+2. Consumer는 acquire load로 true를 확인한 뒤에만 shared_order를 읽는다.
+3. Consumer가 읽은 true는 producer의 release store에서 온 값이다.
+4. Publication 이후에는 shared_order를 동기화 없이 다시 수정하지 않는다.
+```
+
+publication 이후 여러 consumer가 `shared_order`를 읽기만 하는 것은 가능하다.
+
+하지만 producer가 publication 이후 `shared_order`를 다시 수정하면 기존 release/acquire 한 번으로 그 수정까지 보호할 수 없다.
+
+```text
+초기화
+release publication
+consumer의 읽기       -> 보호됨
+
+producer의 추가 수정   -> 별도의 동기화 필요
+consumer의 추가 읽기
+```
+
+또한 `order_ready`를 다시 `false`로 바꿨다가 재사용하는 것만으로 반복 publication protocol이 완성되지는 않는다.
+
+여러 번 갱신하거나 writer가 여러 명이라면 mutex, sequence number, double buffering처럼 상태 전환 전체를 설명할 수 있는 별도 protocol이 필요하다.
+
+release/acquire 한 쌍은 publication 이전의 작업과 acquire 이후의 작업을 연결한다.
+
+객체의 남은 lifetime 전체를 자동으로 보호하는 장치는 아니다.
+
+# 5. Acquire-release ordering
+
+## 5.1 Read-modify-write의 양방향 역할
+
+`memory_order_acq_rel`은 acquire와 release를 결합한 order다.
+
+이 order는 값을 읽으면서 동시에 새로운 값을 쓰는 read-modify-write 연산에 사용한다.
+
+```c
+atomic_fetch_add_explicit(
+    &state,
+    1,
+    memory_order_acq_rel
+);
+```
+
+하나의 연산이 두 역할을 수행한다.
+
+```text
+acquire
+    -> 이전 thread가 release한 작업을 받아들인다.
+
+read-modify-write
+    -> 현재 atomic 값을 읽고 새 값으로 변경한다.
+
+release
+    -> 현재 thread가 앞에서 수행한 작업을 다음 thread에 공개한다.
+```
+
+따라서 이전 상태에 딸린 데이터를 읽은 뒤 새로운 상태와 데이터를 다음 thread에 넘기는 상태 전환에 사용할 수 있다.
+
+단순 통계 counter처럼 주변 데이터를 동기화하지 않는 연산에는 보통 acq_rel까지 필요하지 않다.
+
+## 5.2 Compare-exchange의 성공과 실패
+
+`compare_exchange`는 성공할 때와 실패할 때 하는 일이 다르다.
+
+먼저 compare-exchange의 동작을 일반 코드처럼 표현해보자.
+
+```c
+if (state == expected) {
+    state = desired;
+    return true;
+}
+
+expected = state;
+return false;
+```
+
+실제 compare-exchange는 위 비교와 변경을 하나의 atomic operation으로 수행한다.
+
+```c
+bool changed = atomic_compare_exchange_weak_explicit(
+    &state,
+    &expected,
+    desired,
+    memory_order_acq_rel,
+    memory_order_acquire
+);
+```
+
+### 성공 경로
+
+`state`의 현재 값이 `expected`와 같으면 비교에 성공한다.
+
+```text
+state == expected
+    -> state의 기존 값을 읽음
+    -> state에 desired를 저장
+    -> true 반환
+```
+
+성공 경로는 값을 읽고 새로운 값을 쓰므로 read-modify-write다.
+
+```text
+load state
+compare
+store desired
+
+위 과정 전체가 하나의 atomic operation
+```
+
+다른 thread는 비교와 store 사이에 끼어들어 `state`를 변경할 수 없다.
+
+성공할 때는 `expected`의 값이 변경되지 않는다.
+
+### 실패 경로
+
+`state`의 현재 값이 `expected`와 다르면 비교에 실패한다.
+
+```text
+state != expected
+    -> state의 현재 값만 읽음
+    -> state에는 아무 값도 쓰지 않음
+    -> expected를 state의 현재 값으로 변경
+    -> false 반환
+```
+
+예를 들어 다음 상태에서 CAS를 실행한다고 해보자.
+
+```text
+state    = 3
+expected = 2
+desired  = 4
+```
+
+비교에 실패한 뒤의 값은 다음과 같다.
+
+```text
+state    = 3    // 변경되지 않음
+expected = 3    // 실제 state 값으로 갱신
+반환 값  = false
+```
+
+실패 경로는 atomic 객체에 값을 쓰지 않고 load만 수행한다.
+
+이 차이 때문에 compare-exchange는 success order와 failure order를 따로 받는다.
+
+```text
+success order
+    -> 성공한 read-modify-write 전체에 적용
+
+failure order
+    -> 실패했을 때 수행한 load에만 적용
+```
+
+### Success order의 역할
+
+성공한 compare-exchange에는 read와 write가 모두 있으므로 목적에 따라 여러 order를 사용할 수 있다.
+
+```text
+memory_order_relaxed
+    -> state 전환의 atomicity만 필요
+
+memory_order_acquire
+    -> 기존 state를 만든 thread의 작업을 획득
+
+memory_order_release
+    -> 현재 thread의 앞선 작업을 새 state와 함께 공개
+
+memory_order_acq_rel
+    -> 이전 작업을 획득하고 현재 작업을 다시 공개
+
+memory_order_seq_cst
+    -> acquire/release 의미와 seq_cst 전체 순서가 필요
+```
+
+`memory_order_acq_rel` 성공 경로는 다음 두 방향을 동시에 연결할 수 있다.
+
+```text
+이전 thread의 일반 write
+    sequenced-before
+이전 thread의 release operation
+    synchronizes-with
+현재 thread의 성공한 CAS acquire
+    sequenced-before
+현재 thread의 이후 read
+```
+
+그리고 CAS의 release 쪽은 현재 thread의 앞선 작업을 다음 thread로 넘길 수 있다.
+
+```text
+현재 thread의 일반 write
+    sequenced-before
+현재 thread의 성공한 CAS release
+    synchronizes-with
+다음 thread의 acquire operation
+    sequenced-before
+다음 thread의 이후 read
+```
+
+이를 하나의 상태 handoff로 줄이면 다음과 같다.
+
+```text
+이전 thread의 release
+        |
+        | synchronizes-with
+        v
+성공한 CAS의 acquire + release
+        |
+        | synchronizes-with
+        v
+다음 thread의 acquire
+```
+
+CAS는 acquire 쪽으로 이전 상태에 딸린 작업을 받아들이고, release 쪽으로 현재 thread가 준비한 작업을 새로운 상태와 함께 공개한다.
+
+단순히 숫자 상태 하나만 바꾸고 주변 데이터를 동기화하지 않는다면 acq_rel까지 필요하지 않을 수 있다.
+
+### Failure order의 역할
+
+실패 경로에는 atomic 객체에 대한 write가 없다.
+
+따라서 다른 thread에 현재 thread의 작업을 공개하는 release 의미를 적용할 대상도 없다.
+
+```text
+실패 경로
+    state load
+    expected 갱신
+    return false
+
+state store는 없음
+```
+
+이 때문에 failure order에는 `memory_order_release`와 `memory_order_acq_rel`을 사용할 수 없다.
+
+실패 후 무엇을 하느냐에 따라 relaxed와 acquire를 선택할 수 있다.
+
+```text
+실패 후 expected 값만 비교하고 다시 시도
+    -> memory_order_relaxed를 검토
+
+실패하면서 읽은 state에 연결된 일반 데이터를 사용
+    -> memory_order_acquire를 검토
+```
+
+예를 들어 실패한 현재 상태만 확인하고 함수를 종료한다면 failure acquire가 필요하지 않을 수 있다.
+
+```c
+bool try_change_state(int desired) {
+    int expected = STATE_READY;
+
+    return atomic_compare_exchange_strong_explicit(
+        &state,
+        &expected,
+        desired,
+        memory_order_acq_rel,
+        memory_order_relaxed
+    );
+}
+```
+
+반면 실패하면서 읽은 `expected`가 다른 thread가 release로 공개한 상태이고, 실패 경로에서 그 상태에 딸린 데이터를 읽어야 한다면 acquire가 필요할 수 있다.
+
+```c
+if (!atomic_compare_exchange_strong_explicit(
+        &state,
+        &expected,
+        desired,
+        memory_order_acq_rel,
+        memory_order_acquire)) {
+    inspect_data_for(expected);
+}
+```
+
+이 코드는 `inspect_data_for`가 실제로 어떤 데이터를 읽고 그 데이터를 누가 어떻게 공개했는지까지 함께 확인해야 한다.
+
+failure order를 acquire로 지정했다는 사실만으로 임의의 데이터가 자동으로 보호되지는 않는다.
+
+### Weak CAS의 재시도
+
+`atomic_compare_exchange_weak`는 `state == expected`여도 spurious failure를 허용한다.
+
+따라서 일반적으로 loop 안에서 사용한다.
+
+```c
+bool change_ready_to_running(void) {
+    int expected = STATE_READY;
+
+    while (!atomic_compare_exchange_weak_explicit(
+        &state,
+        &expected,
+        STATE_RUNNING,
+        memory_order_acq_rel,
+        memory_order_relaxed
+    )) {
+        if (expected != STATE_READY) {
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+실패할 때마다 `expected`에는 CAS가 읽은 현재 `state` 값이 들어간다.
+
+```text
+첫 시도
+    expected = STATE_READY
+
+다른 값 때문에 실패
+    expected = 현재 state
+
+spurious failure
+    state가 여전히 STATE_READY라면 expected도 STATE_READY
+    loop에서 다시 시도
+```
+
+위 loop는 실패 후 상태 값만 검사하므로 failure order로 relaxed를 사용한다.
+
+성공 이후 이전 thread가 공개한 데이터가 필요하고, 성공 이전의 작업도 다음 thread에 공개해야 한다는 전제에서 success order로 acq_rel을 사용했다.
+
+실제 코드에서는 이 두 요구가 모두 있는지 확인해야 한다.
+
+### 유효한 order 조합
+
+failure order는 success order보다 더 강할 수 없다.
+
+`memory_order_consume`을 제외하고 자주 사용하는 유효 조합을 정리하면 다음과 같다.
+
+| Success order | 사용 가능한 failure order |
+|---|---|
+| `memory_order_relaxed` | `memory_order_relaxed` |
+| `memory_order_acquire` | `memory_order_relaxed`, `memory_order_acquire` |
+| `memory_order_release` | `memory_order_relaxed` |
+| `memory_order_acq_rel` | `memory_order_relaxed`, `memory_order_acquire` |
+| `memory_order_seq_cst` | `memory_order_relaxed`, `memory_order_acquire`, `memory_order_seq_cst` |
+
+실패 경로는 load일 뿐이므로 release 의미를 가질 수 없다는 원칙으로 보면 표를 이해하기 쉽다.
+
+```text
+성공
+    read + write
+    -> acquire와 release 모두 가능
+
+실패
+    read only
+    -> acquire는 가능
+    -> release는 불가능
+```
+
+compare-exchange에서 memory order를 선택할 때는 성공과 실패를 별도 실행 경로로 그려보는 것이 좋다.
+
+```text
+성공 후 어떤 데이터를 읽는가?
+성공 전에 준비한 무엇을 공개하는가?
+실패 후 expected만 검사하는가?
+실패하며 관찰한 상태에 딸린 데이터를 읽는가?
+```
+
+이 질문에 대한 답이 success order와 failure order를 결정한다.
+
+# 6. Sequential consistency
+
+## 6.1 기본 memory order
+
+`memory_order_seq_cst`는 sequentially consistent ordering을 의미한다.
+
+`_explicit`이 없는 기본 atomic API는 seq_cst를 사용한다.
+
+```c
+atomic_store(&ready, true);
+atomic_load(&ready);
+atomic_fetch_add(&counter, 1);
+```
+
+위 코드는 각각 다음과 같은 의미다.
+
+```c
+atomic_store_explicit(&ready, true, memory_order_seq_cst);
+atomic_load_explicit(&ready, memory_order_seq_cst);
+atomic_fetch_add_explicit(&counter, 1, memory_order_seq_cst);
+```
+
+seq_cst load에는 acquire 의미가 있고, seq_cst store에는 release 의미가 있다.
+
+read-modify-write에는 양쪽 의미가 포함된다.
+
+여기에 더해 모든 seq_cst 연산이 thread들이 동의할 수 있는 하나의 total order에 놓인다는 강한 제약을 제공한다.
+
+## 6.2 단일 전체 순서
+
+두 atomic 변수를 사용하는 예제를 보자.
+
+```c
+atomic_int x = 0;
+atomic_int y = 0;
+
+// Thread A
+atomic_store_explicit(&x, 1, memory_order_seq_cst);
+int r1 = atomic_load_explicit(&y, memory_order_seq_cst);
+
+// Thread B
+atomic_store_explicit(&y, 1, memory_order_seq_cst);
+int r2 = atomic_load_explicit(&x, memory_order_seq_cst);
+```
+
+seq_cst에서는 두 thread가 모두 `0`을 읽는 결과를 허용하지 않는다.
+
+```text
+r1 == 0 && r2 == 0  -> 허용되지 않음
+```
+
+모든 seq_cst 연산을 하나의 순서로 놓으면서 각 thread의 코드 순서도 지키려 하면, 두 load가 모두 상대편 store보다 먼저 와야 하는 모순이 생기기 때문이다.
+
+```text
+x = 1  <  y 읽기     Thread A의 순서
+y = 1  <  x 읽기     Thread B의 순서
+
+y 읽기가 0을 보려면  y 읽기 < y = 1
+x 읽기가 0을 보려면  x 읽기 < x = 1
+
+모두 연결하면 순환이 생겨 하나의 total order를 만들 수 없다.
+```
+
+같은 코드를 relaxed로 작성하면 두 load가 모두 `0`을 읽는 결과가 허용될 수 있다.
+
+seq_cst의 강점은 여러 atomic 객체가 섞인 코드에서도 가능한 실행 결과를 더 직관적으로 제한한다는 점이다.
+
+## 6.3 강한 보장과 비용
+
+seq_cst가 항상 별도의 무거운 명령으로 바뀌는 것은 아니다.
+
+실제 비용은 CPU architecture, 연산 종류, compiler가 선택한 명령에 따라 다르다.
+
+어떤 target에서는 acquire/release와 같은 명령이 나올 수 있고, 다른 target이나 연산에서는 추가 fence 또는 더 강한 명령이 필요할 수 있다.
+
+따라서 다음처럼 판단하면 안 된다.
+
+```text
+relaxed는 항상 빠르다.
+seq_cst는 항상 느리다.
+```
+
+다만 seq_cst는 compiler와 CPU에 더 강한 순서 제약을 요구하므로 최적화와 구현의 자유를 더 제한할 수 있다.
+
+정확성이 우선이라면 기본 seq_cst로 시작하고, 병목을 측정한 뒤 더 약한 order로 바꾸는 접근이 안전하다.
+
+# 7. Consume과 fence
+
+## 7.1 Consume ordering
+
+C11에는 `memory_order_consume`도 정의되어 있다.
+
+consume은 acquire보다 약한 형태로, atomic load에서 얻은 값에 대한 dependency를 따라 ordering을 제공하려는 목적을 가진다.
+
+```text
+acquire
+    -> load 이후의 일반적인 memory 접근에 ordering 제공
+
+consume
+    -> 읽은 값에 의존하는 memory 접근을 중심으로 ordering 제공
+```
+
+하지만 dependency의 의미를 language와 compiler 최적화에 걸쳐 정확하게 다루기 어렵다.
+
+실제 compiler는 consume을 더 강한 acquire처럼 구현하는 경우가 일반적이다.
+
+따라서 실무 C 코드에서는 특별한 이유와 target 검증이 없다면 `memory_order_acquire`를 사용하는 편이 이해하고 유지하기 쉽다.
+
+## 7.2 Atomic fence
+
+`atomic_thread_fence`는 특정 atomic 객체를 직접 읽거나 쓰지 않고 ordering 제약만 만든다.
+
+```c
+atomic_thread_fence(memory_order_acquire);
+atomic_thread_fence(memory_order_release);
+atomic_thread_fence(memory_order_seq_cst);
+```
+
+fence는 단독으로 임의의 thread를 동기화하지 않는다.
+
+어떤 atomic 객체의 load와 store가 fence를 연결하는지까지 함께 증명해야 한다.
+
+잘못 배치한 fence는 코드만 복잡하게 만들고 필요한 happens-before 관계를 만들지 못할 수 있다.
+
+처음에는 ordering을 atomic load, store, read-modify-write에 직접 지정하는 방식이 더 명확하다.
+
+# 8. 연산별 memory order
+
+## 8.1 Load와 store
+
+모든 atomic 연산에 모든 memory order를 사용할 수 있는 것은 아니다.
+
+atomic load는 값을 쓰지 않으므로 release 의미를 가질 수 없다.
+
+```text
+atomic load에서 사용 가능
+    memory_order_relaxed
+    memory_order_consume
+    memory_order_acquire
+    memory_order_seq_cst
+
+atomic load에서 사용 불가
+    memory_order_release
+    memory_order_acq_rel
+```
+
+atomic store는 값을 읽어 획득하지 않으므로 acquire 의미를 가질 수 없다.
+
+```text
+atomic store에서 사용 가능
+    memory_order_relaxed
+    memory_order_release
+    memory_order_seq_cst
+
+atomic store에서 사용 불가
+    memory_order_consume
+    memory_order_acquire
+    memory_order_acq_rel
+```
+
+## 8.2 Read-modify-write
+
+`exchange`, `fetch_add`, 성공한 `compare_exchange` 같은 read-modify-write는 값을 읽고 쓰기 때문에 다양한 order를 사용할 수 있다.
+
+```text
+read-modify-write에서 사용 가능
+    memory_order_relaxed
+    memory_order_consume
+    memory_order_acquire
+    memory_order_release
+    memory_order_acq_rel
+    memory_order_seq_cst
+```
+
+필요한 의미에 따라 선택한다.
+
+```text
+atomicity만 필요                     -> relaxed
+이전 thread의 작업을 받아야 함        -> acquire
+현재 thread의 작업을 공개해야 함       -> release
+받기와 공개를 모두 해야 함             -> acq_rel
+seq_cst 전체 순서까지 필요             -> seq_cst
+```
+
+## 8.3 Compare-exchange의 failure order
+
+compare-exchange 실패 경로는 store를 수행하지 않는다.
+
+따라서 failure order에는 release 의미를 지정할 수 없다.
+
+```text
+failure order에서 사용 가능
+    memory_order_relaxed
+    memory_order_consume
+    memory_order_acquire
+    memory_order_seq_cst
+
+failure order에서 사용 불가
+    memory_order_release
+    memory_order_acq_rel
+```
+
+failure order는 success order보다 강할 수도 없다.
+
+명시적 compare-exchange를 사용할 때 이 규칙을 놓치기 쉬우므로 compiler warning을 확인해야 한다.
+
+# 9. Memory order 선택 기준
+
+## 9.1 독립적인 atomic 값
+
+다른 일반 데이터를 보호하거나 공개하지 않고 atomic 값 자체의 정확성만 필요하다면 relaxed를 검토할 수 있다.
+
+```text
+통계 counter
+이벤트 발생 횟수
+독립적인 reference count의 증감
+```
+
+reference count도 객체 파괴와 lifetime 동기화 단계에서는 더 강한 order가 필요할 수 있으므로 전체 알고리즘을 따로 검토해야 한다.
+
+## 9.2 데이터 공개와 전달
+
+한 thread가 작성한 일반 데이터를 flag나 pointer를 통해 다른 thread에 전달한다면 release/acquire가 대표적인 선택이다.
+
+```text
+Producer
+    data 작성
+    release store로 ready 공개
+
+Consumer
+    acquire load로 ready 확인
+    data 사용
+```
+
+이때 acquire가 release가 저장한 값 또는 그에 연결된 release sequence의 값을 읽는지 확인해야 한다.
+
+## 9.3 상태 전환
+
+현재 상태와 이전 thread의 결과를 획득하면서 새로운 상태를 다음 thread에 공개하는 read-modify-write라면 acq_rel을 검토할 수 있다.
+
+```text
+CAS 기반 상태 전환
+소유권 handoff
+lock-free 자료구조의 node 연결
+```
+
+이 영역에서는 객체 lifetime, ABA 문제, memory reclamation까지 함께 고려해야 하므로 memory order만 맞춘다고 알고리즘 전체가 안전해지는 것은 아니다.
+
+## 9.4 기본값과 최적화
+
+memory order를 확신하기 어렵다면 seq_cst로 시작하는 것이 좋다.
+
+```text
+1. 먼저 seq_cst로 올바른 알고리즘을 작성한다.
+2. test와 sanitizer로 기본적인 오류를 확인한다.
+3. profiler와 benchmark로 실제 병목을 측정한다.
+4. happens-before 관계를 설명할 수 있는 연산만 약하게 바꾼다.
+5. target architecture에서 assembly와 성능을 다시 확인한다.
+```
+
+약한 memory order는 단순한 성능 옵션이 아니다.
+
+프로그램이 허용하는 실행 결과 자체를 바꾸는 correctness 조건이다.
+
+# 정리
+
+이번 글에서는 C atomic operation의 memory order를 살펴봤다.
+
+핵심은 다음과 같다.
+
+```text
+atomicity는 atomic 객체 자체의 연산을 나뉘지 않게 한다.
+memory ordering은 주변 memory 접근의 관찰 순서를 정한다.
+sequenced-before는 C abstract machine의 thread 내부 관계다.
+sequenced-before가 실제 CPU 명령이나 다른 core의 관찰 순서를 뜻하지는 않는다.
+relaxed도 atomicity는 유지하지만 thread 사이의 동기화를 만들지 않는다.
+relaxed는 서로 다른 atomic 객체의 관찰 순서를 연결하지 않는다.
+release store와 그 값을 읽은 acquire load는 synchronizes-with 관계를 만든다.
+이 관계를 통해 앞선 write와 뒤의 read 사이에 happens-before가 형성된다.
+acq_rel은 read-modify-write에서 acquire와 release 역할을 함께 수행한다.
+seq_cst는 acquire/release 의미와 seq_cst 연산 사이의 단일 total order를 제공한다.
+consume은 실무에서 acquire로 대체되는 경우가 많다.
+fence는 atomic 연산과의 연결까지 함께 이해해야 한다.
+약한 memory order는 측정 전에 적용하는 단순한 성능 최적화가 아니다.
+```
+
+memory order를 선택할 때는 "이 연산이 얼마나 강해야 하는가"보다 먼저 "어떤 write가 어떤 read보다 happens-before여야 하는가"를 그려보는 것이 좋다.
+
+다음 글에서는 atomic과 mutex를 실제 코드 관점에서 비교하고, spinlock 구현을 통해 atomic으로 lock을 만들 때 생기는 장점과 한계를 정리한다.
+
+# 참고 자료
+
+- [C11 draft N1570](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)
+- [C Memory Model Rationale N1479](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1479.htm)
+- [GCC - Built-in Functions for Memory Model Aware Atomic Operations](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)
+- [LLVM Atomic Instructions and Concurrency Guide](https://llvm.org/docs/Atomics.html)

--- a/_posts/2026-08-05-cpu-device-communication.md
+++ b/_posts/2026-08-05-cpu-device-communication.md
@@ -1,0 +1,280 @@
+---
+title: '[Device I/O] CPU는 Device와 어떻게 통신하는가'
+date: 2026-08-05 00:20:00 +09:00
+categories: [computer, device I/O]
+published: false
+tags:
+  [
+    device I/O,
+    bus,
+    device register,
+    MMIO,
+    doorbell
+  ]
+---
+
+# 개요
+
+CPU에서 다음과 같이 값을 저장한다고 생각해보자.
+
+```c
+*address = value;
+```
+
+이 명령은 DRAM에 값을 기록할 수도 있지만 device register에 명령을 전달할 수도 있다.
+
+CPU는 SSD 내부 함수를 직접 호출하지 않는다.
+
+CPU가 실행하는 것은 driver의 instruction이며, driver는 device가 공개한 register와 host memory의 자료 구조를 통해 작업을 요청한다.
+
+```text
+CPU가 driver instruction 실행
+    ↓
+Driver가 command를 host memory에 작성
+    ↓
+Driver가 device register에 작업 시작을 알림
+    ↓
+Device controller가 독립적으로 작업 수행
+    ↓
+Device가 완료 상태를 기록
+```
+
+# 1. CPU와 Device는 서로 다른 실행 주체다
+
+CPU는 application과 OS의 instruction stream을 실행한다.
+
+Device controller는 자체 state machine, processor 또는 firmware에 따라 비동기적으로 동작한다.
+
+따라서 다음 호출처럼 CPU가 device의 내부 함수를 직접 실행하는 구조가 아니다.
+
+```c
+ssd_read(logical_block, buffer);
+```
+
+Driver가 이런 형태의 interface를 제공할 수는 있지만 그 내부에서는 register와 memory를 이용한 통신이 일어난다.
+
+```text
+Software function call
+    ↓
+Driver가 command와 buffer 준비
+    ↓
+Hardware protocol을 통해 device에 요청
+```
+
+CPU와 device는 서로 다른 속도로 동작한다.
+
+CPU가 요청을 보낸 뒤 완료될 때까지 멈춰 있기보다 다른 작업을 수행하고 나중에 완료를 확인하는 비동기 구조가 필요하다.
+
+# 2. Bus란 무엇인가
+
+Bus는 CPU, memory, device 사이에 transaction을 전달하는 통신 체계다.
+
+단순히 여러 부품을 연결하는 전선만을 의미하지 않는다.
+
+Transaction에는 다음 정보가 필요하다.
+
+- 어느 대상에 접근하는가
+- Read와 write 중 어떤 작업인가
+- 어떤 data를 전달하는가
+- 요청에 대한 응답과 오류를 어떻게 처리하는가
+- 여러 transaction의 순서를 어떻게 다루는가
+
+현대 computer는 하나의 공유 bus만 사용하지 않는다.
+
+```text
+CPU Core
+  ↓
+CPU Interconnect
+  ↓
+Memory Controller 또는 PCIe Root Complex
+  ↓
+DRAM 또는 PCIe Device
+```
+
+각 구간의 protocol과 구현은 다를 수 있다.
+
+Software는 이 복잡한 연결을 address와 OS interface를 통해 사용한다.
+
+# 3. Device Controller
+
+Device controller는 host의 요청을 해석하고 실제 hardware 동작을 제어한다.
+
+NVMe SSD controller를 예로 들면 다음과 같은 작업을 수행한다.
+
+- PCIe와 NVMe protocol 처리
+- Submission Queue의 command fetch
+- Host memory와 SSD 사이의 DMA
+- Command scheduling
+- FTL mapping
+- NAND channel과 die scheduling
+- 오류 검출과 복구
+- Completion 생성
+
+Controller가 어떤 작업을 hardware logic으로 수행하고 어떤 작업을 firmware로 수행하는지는 구현에 따라 달라진다.
+
+# 4. Device Register
+
+Device register는 controller가 host software에 공개하는 제어·상태 interface다.
+
+| 역할 | 예시 |
+| --- | --- |
+| Configuration | 기능 활성화와 mode 설정 |
+| Command notification | 새 command가 있음을 알리는 doorbell |
+| Status | ready, busy, error 확인 |
+| Interrupt control | interrupt mask와 pending 상태 처리 |
+
+Device register와 일반 RAM은 동일한 load/store 문법으로 접근할 수 있어도 의미가 다르다.
+
+## 4.1 일반 Memory Write
+
+```c
+memory[index] = value;
+```
+
+일반적으로 해당 위치에 값을 저장한다.
+
+## 4.2 Register Write
+
+```c
+device_register = command;
+```
+
+단순한 값 저장이 아니라 다음 side effect를 일으킬 수 있다.
+
+- Device 동작 시작
+- Queue tail 갱신
+- Interrupt acknowledge
+- Error 상태 초기화
+- Device reset
+
+Register read에도 side effect가 존재할 수 있다.
+
+예를 들어 status register를 읽는 순간 pending bit가 해제되는 read-to-clear register가 있을 수 있다.
+
+따라서 device specification이 정의한 access width, 허용 값, 순서와 side effect를 확인해야 한다.
+
+# 5. MMIO
+
+MMIO(Memory-Mapped I/O)는 device register를 CPU의 physical address space 일부에 배치하는 방식이다.
+
+CPU는 load/store instruction을 사용하지만 address에 따라 transaction의 목적지가 달라진다.
+
+```text
+CPU Load / Store
+       ↓
+Address Decode
+       ├─ DRAM 영역 → Memory Controller
+       └─ MMIO 영역 → Device Register
+```
+
+MMIO는 device register가 실제 RAM에 저장된다는 의미가 아니다.
+
+동일한 address access instruction으로 device register에 접근할 수 있도록 mapping한다는 의미다.
+
+## 5.1 MMIO Mapping
+
+OS는 PCIe BAR 같은 hardware resource를 확인하고 driver가 접근할 수 있는 virtual address에 mapping한다.
+
+개념적으로 다음 변환이 일어난다.
+
+```text
+Driver Virtual Address
+    ↓ page table / OS mapping
+MMIO Physical Address Range
+    ↓ interconnect routing
+Device Register
+```
+
+Driver는 mapping된 virtual address를 사용하지만 실제 transaction은 DRAM이 아니라 device로 전달된다.
+
+## 5.2 MMIO 접근 시 주의점
+
+MMIO는 일반 memory와 동일하게 다루면 안 된다.
+
+- Compiler가 access를 제거하거나 합치지 않아야 한다.
+- CPU와 interconnect의 ordering 규칙을 고려해야 한다.
+- 일반 cacheable memory와 같은 cache 정책을 가정하면 안 된다.
+- Register가 요구하는 access width를 지켜야 한다.
+- Read/write가 일으키는 side effect를 고려해야 한다.
+
+Linux driver에서는 pointer를 직접 역참조하기보다 `readl()`과 `writel()` 같은 accessor를 사용한다.
+
+Architecture별 MMIO access와 ordering 차이를 OS가 제공하는 API를 통해 처리하기 위해서다.
+
+# 6. volatile이면 충분할까
+
+`volatile`은 compiler가 access를 불필요하다고 판단하여 제거하거나 임의로 합치는 것을 제한하는 데 사용될 수 있다.
+
+그러나 `volatile`만으로 다음 사항이 모두 보장되지는 않는다.
+
+- CPU의 memory ordering
+- 다른 core와의 synchronization
+- DMA 결과의 visibility
+- Cache coherence가 없는 device와의 일관성
+- Descriptor write와 doorbell write의 순서
+
+따라서 MMIO에는 OS가 제공하는 accessor를 사용하고, DMA와 descriptor에는 해당 환경이 제공하는 memory barrier와 DMA API를 사용해야 한다.
+
+# 7. Doorbell
+
+Command 전체를 MMIO register에 하나씩 쓰는 구조는 MMIO transaction이 많아지고 확장성이 떨어진다.
+
+고성능 device는 command를 host memory의 queue에 저장하고 MMIO에는 작은 알림만 쓰는 방식을 사용할 수 있다.
+
+이 알림 register를 doorbell이라고 부른다.
+
+```text
+1. CPU가 host memory의 Submission Queue entry 작성
+2. Entry가 device에 보이도록 ordering 보장
+3. CPU가 MMIO doorbell에 새 tail 값 기록
+4. Device가 Submission Queue entry를 DMA read
+```
+
+Doorbell은 command payload 자체가 아니다.
+
+새 command가 memory의 어디까지 준비되었는지 device에 알려주는 신호에 가깝다.
+
+# 8. Ordering이 필요한 이유
+
+CPU 관점의 program order가 device가 관찰하는 순서와 항상 같다고 가정할 수는 없다.
+
+다음 두 작업을 생각해보자.
+
+```text
+A. Host memory에 descriptor 작성
+B. MMIO doorbell write
+```
+
+Device는 반드시 완성된 descriptor를 읽어야 하므로 A가 B보다 먼저 관찰되어야 한다.
+
+순서가 보장되지 않으면 device가 doorbell을 먼저 확인하고 아직 완성되지 않은 descriptor를 DMA read할 수 있다.
+
+구체적으로 어떤 barrier와 accessor가 필요한지는 CPU architecture, OS와 device의 DMA coherence model에 따라 달라진다.
+
+중요한 것은 다음 불변식이다.
+
+> Descriptor의 모든 field가 device에 보이는 상태가 된 후에 device에 descriptor의 존재를 알린다.
+
+# 정리
+
+CPU와 device의 통신은 다음 구조로 이해할 수 있다.
+
+```text
+CPU / Driver
+    │ host memory에 command 작성
+    │ MMIO register로 알림
+    ▼
+Bus / Interconnect
+    ▼
+Device Controller
+    │ command 해석
+    │ hardware와 firmware 동작
+    ▼
+Completion
+```
+
+Device register는 일반 memory와 의미가 다르며, register access는 hardware side effect를 일으킬 수 있다.
+
+MMIO를 통해 CPU instruction으로 register에 접근할 수 있지만 compiler ordering, CPU ordering과 DMA visibility까지 `volatile` 하나로 해결할 수는 없다.
+
+다음 글에서는 device가 완료 사실을 알리는 interrupt와 CPU가 직접 완료를 확인하는 polling을 비교하고, DMA가 이 흐름에서 어떤 역할을 하는지 살펴본다.

--- a/_posts/2026-08-05-interrupt-polling-dma.md
+++ b/_posts/2026-08-05-interrupt-polling-dma.md
@@ -1,0 +1,279 @@
+---
+title: '[Device I/O] Interrupt와 Polling, DMA는 어떻게 연결되는가'
+date: 2026-08-05 00:30:00 +09:00
+categories: [computer, device I/O]
+published: false
+tags:
+  [
+    interrupt,
+    polling,
+    DMA,
+    MSI-X,
+    device I/O
+  ]
+---
+
+# 개요
+
+Device I/O를 공부할 때 interrupt, polling과 DMA를 하나의 선택지처럼 비교하기 쉽다.
+
+하지만 이들은 서로 다른 문제를 해결한다.
+
+```text
+DMA
+  → Payload를 누가 이동하는가?
+
+Interrupt와 Polling
+  → CPU가 완료 사실을 어떻게 발견하는가?
+```
+
+따라서 device가 DMA로 데이터를 옮긴 뒤 interrupt로 완료를 알릴 수도 있고, CPU가 completion queue를 polling하여 완료를 발견할 수도 있다.
+
+# 1. 비동기 Device I/O
+
+CPU와 device는 서로 독립적으로 동작한다.
+
+CPU가 I/O command를 제출한 직후에는 device의 작업이 끝나지 않았을 수 있다.
+
+```text
+CPU: command 제출 ─────────────── completion 처리
+                         ▲
+Device:        command 처리 → data 이동 → 완료 기록
+```
+
+이 구조에는 두 가지 문제가 있다.
+
+1. CPU와 device 사이에서 payload를 어떻게 이동할 것인가?
+2. Device의 작업 완료를 CPU가 어떻게 알 것인가?
+
+첫 번째 문제에 DMA가 사용되고, 두 번째 문제에 interrupt 또는 polling이 사용된다.
+
+# 2. CPU Copy
+
+DMA가 없다면 CPU가 device register나 작은 I/O window를 반복해서 읽고 쓰며 데이터를 옮기는 방식을 생각할 수 있다.
+
+```text
+Device → CPU Register → CPU Instruction → Memory
+```
+
+이 방식에서는 데이터 이동 중 CPU가 계속 instruction을 실행해야 한다.
+
+Payload가 크거나 I/O 요청이 많으면 CPU가 단순 복사에 많은 시간을 사용한다.
+
+# 3. DMA
+
+DMA(Direct Memory Access)는 DMA-capable device 또는 DMA engine이 CPU 대신 memory와 device 사이의 데이터를 전송하는 방식이다.
+
+CPU가 아무 일도 하지 않는다는 뜻은 아니다.
+
+CPU와 driver는 전송을 준비하고 device는 실제 payload를 옮긴다.
+
+```text
+CPU / Driver
+  1. Buffer 준비
+  2. DMA mapping
+  3. Descriptor 작성
+  4. Device에 시작 알림
+          ↓
+Device DMA Engine
+  5. Descriptor 읽기
+  6. Payload read 또는 write
+  7. Completion 기록
+          ↓
+CPU / Driver
+  8. 완료 처리
+  9. Buffer 재사용 또는 해제
+```
+
+## 3.1 DMA Read와 DMA Write
+
+관점은 device를 기준으로 구분한다.
+
+- DMA read: device가 host memory의 data를 읽는다.
+- DMA write: device가 host memory에 data를 쓴다.
+
+NVMe read command에서는 SSD가 NAND에서 읽은 payload를 host buffer에 DMA write한다.
+
+NVMe write command에서는 SSD가 host buffer의 payload를 DMA read한다.
+
+## 3.2 DMA의 핵심 질문
+
+DMA 코드를 읽을 때는 다음 질문을 확인해야 한다.
+
+1. Buffer를 누가 할당했는가?
+2. CPU가 사용하는 address와 device가 사용하는 address는 무엇인가?
+3. Mapping의 방향은 무엇인가?
+4. 현재 buffer의 소유권은 CPU와 device 중 누구에게 있는가?
+5. Device에 buffer가 보이도록 어떤 synchronization을 수행하는가?
+6. Completion 후 언제 unmap하거나 재사용할 수 있는가?
+7. Timeout과 reset 시 outstanding buffer를 어떻게 회수하는가?
+
+# 4. Interrupt
+
+Interrupt는 device가 CPU에 처리할 event가 있음을 알리는 방법이다.
+
+```text
+Device가 작업 완료
+    ↓
+Completion 정보 기록
+    ↓
+Interrupt 발생
+    ↓
+CPU가 현재 실행 흐름 전환
+    ↓
+Interrupt handler가 원인 확인
+    ↓
+Completion 처리 또는 후속 작업 예약
+```
+
+CPU는 I/O가 끝날 때까지 같은 위치에서 기다릴 필요가 없다.
+
+다른 작업을 실행하거나 idle 상태에 들어갔다가 interrupt를 받고 완료를 처리할 수 있다.
+
+## 4.1 Interrupt의 장점
+
+- Event가 드물 때 CPU를 효율적으로 사용할 수 있다.
+- CPU가 busy loop를 수행하지 않아도 된다.
+- Device의 비동기 event를 처리하기 적합하다.
+
+## 4.2 Interrupt의 비용
+
+- 현재 실행 흐름을 전환해야 한다.
+- Handler와 후속 처리 비용이 발생한다.
+- Cache와 branch predictor locality가 나빠질 수 있다.
+- Event가 너무 많으면 interrupt storm이 발생할 수 있다.
+
+## 4.3 Interrupt Coalescing
+
+Device가 completion마다 interrupt를 발생시키지 않고 여러 completion을 모아 한 번에 알릴 수 있다.
+
+```text
+Completion 1 ┐
+Completion 2 ├─ 하나의 Interrupt
+Completion 3 ┘
+```
+
+Interrupt 수가 감소하므로 CPU overhead와 처리량에는 유리할 수 있다.
+
+반면 첫 번째 completion이 다음 completion을 기다리게 되면 latency가 증가할 수 있다.
+
+# 5. MSI와 MSI-X
+
+전통적인 interrupt pin 대신 PCIe device는 memory write 형태의 message로 interrupt를 전달할 수 있다.
+
+이를 MSI(Message Signaled Interrupt)라고 한다.
+
+MSI-X는 더 많은 interrupt vector와 독립적인 설정을 제공하여 multi-queue device에 적합하다.
+
+```text
+NVMe Queue 0 → MSI-X Vector 0 → CPU 0
+NVMe Queue 1 → MSI-X Vector 1 → CPU 1
+NVMe Queue 2 → MSI-X Vector 2 → CPU 2
+```
+
+Queue와 CPU를 적절히 연결하면 여러 core가 하나의 interrupt와 lock을 두고 경쟁하는 문제를 줄일 수 있다.
+
+하지만 queue, interrupt와 application thread가 서로 다른 NUMA node에 배치되면 remote memory access와 cache 이동이 증가할 수 있다.
+
+# 6. Polling
+
+Polling은 CPU가 status register 또는 host memory의 completion queue를 반복해서 확인하는 방식이다.
+
+```c
+while (!completion_ready()) {
+    // 계속 확인
+}
+```
+
+실제 구현은 단순 loop보다 batching, pause instruction, timeout과 scheduler 연동 등을 포함할 수 있다.
+
+## 6.1 Polling의 장점
+
+- Interrupt 전달과 context 전환 지연을 줄일 수 있다.
+- 지속적으로 event가 발생하는 환경에서 한 번에 여러 completion을 처리할 수 있다.
+- 낮고 예측 가능한 latency가 중요한 상황에 유리할 수 있다.
+
+## 6.2 Polling의 비용
+
+- 완료되지 않은 시간에도 CPU cycle을 소비한다.
+- 전력 소비가 증가한다.
+- 공유 memory를 지나치게 읽으면 cache와 interconnect traffic이 증가한다.
+- Polling thread에 전용 CPU를 할당하면 다른 작업에 사용할 core가 줄어든다.
+
+# 7. Interrupt와 Polling의 선택
+
+| 기준 | Interrupt | Polling |
+| --- | --- | --- |
+| 낮은 요청 빈도 | 유리 | CPU 낭비가 큼 |
+| 지속적인 고부하 | Interrupt overhead 증가 | Batching에 유리할 수 있음 |
+| 완료 latency | 전달 및 scheduling 지연 존재 | 전용 CPU 사용 시 낮출 수 있음 |
+| CPU 사용량 | Event가 적으면 낮음 | 대기 중에도 높음 |
+| 전력 | 상대적으로 유리 | 상대적으로 불리 |
+| 구현 고려사항 | Affinity, coalescing | Timeout, fairness, core 할당 |
+
+둘 중 하나만 고집할 필요는 없다.
+
+낮은 부하에서는 interrupt를 사용하고 높은 부하에서는 polling으로 전환하는 hybrid 방식도 가능하다.
+
+# 8. NVMe Read에서의 연결
+
+NVMe read command 하나의 흐름을 살펴보자.
+
+```text
+1. Driver가 host memory에 SQ entry 작성
+2. Driver가 MMIO doorbell write
+3. Controller가 SQ entry를 DMA read
+4. Controller가 FTL을 통해 NAND 위치 확인
+5. NAND page read
+6. Controller가 host buffer에 payload DMA write
+7. Controller가 CQ entry를 DMA write
+8. Controller가 MSI-X interrupt 발생
+   또는 CPU가 CQ polling
+9. Driver가 request 완료 처리
+```
+
+여기에서 각 메커니즘의 역할은 다음과 같다.
+
+- MMIO doorbell: 새 command의 존재를 알린다.
+- DMA: Command, payload와 completion을 memory에서 읽거나 쓴다.
+- Interrupt/polling: CPU가 completion을 발견한다.
+
+# 9. Memory Ordering과 Ownership
+
+비동기 I/O에서는 buffer의 소유권 전환이 중요하다.
+
+```text
+CPU가 descriptor 작성 중
+  → 소유자: CPU
+
+Doorbell을 통해 device에 제출
+  → 소유자: Device
+
+Device가 completion 기록
+  → 소유자: CPU로 반환
+```
+
+CPU는 device에 제출한 buffer를 completion 전에 수정하거나 해제하면 안 된다.
+
+Device가 completion을 기록하기 전에 payload write가 완료되어야 하며, CPU는 completion을 확인한 뒤 올바른 ordering으로 payload를 읽어야 한다.
+
+이 규칙은 다음 한 문장으로 정리할 수 있다.
+
+> Buffer를 상대에게 넘기기 전에 내용을 완성하고, 소유권을 돌려받기 전에는 다시 사용하지 않는다.
+
+# 정리
+
+DMA와 interrupt는 서로 대체하는 기술이 아니다.
+
+```text
+DMA: Data 이동
+Interrupt/Polling: 완료 발견
+```
+
+Driver는 buffer와 descriptor를 준비하고 device에 작업을 알린다.
+
+Device는 DMA를 통해 command와 payload를 처리하고 completion을 기록한다.
+
+CPU는 interrupt 또는 polling으로 completion을 발견한다.
+
+이 전체 흐름을 이해하려면 address, memory ordering과 buffer ownership을 함께 봐야 한다.

--- a/_posts/2026-08-05-memory-system-storage-study-roadmap.md
+++ b/_posts/2026-08-05-memory-system-storage-study-roadmap.md
@@ -1,0 +1,251 @@
+---
+title: '[Memory System] 삼성전자 메모리사업부 지원을 위한 학습 로드맵'
+date: 2026-08-05 00:10:00 +09:00
+categories: [computer, storage]
+published: false
+tags:
+  [
+    memory system,
+    device I/O,
+    PCIe,
+    NVMe,
+    NAND,
+    FTL
+  ]
+---
+
+# 개요
+
+삼성전자 메모리사업부의 다음 직무를 준비하기 위해 필요한 지식을 정리한다.
+
+| 세부 트랙 | 현재 적합도 | 경력과의 연결점 |
+| --- | ---: | --- |
+| Firmware Simulator·Test Platform | 8/10 | 코드, 테스트, 자동화 및 재현 경험 |
+| Storage 성능 분석·Modeling | 8/10 | DBMS 성능 최적화와 병목 분석 경험 |
+| System Level 검증·호환성 분석 | 7/10 | Linux, 디버깅, 장애 재현 경험 |
+
+목표는 용어를 따로 암기하는 것이 아니다.
+
+하나의 I/O 요청이 application에서 출발해 NAND에 도달하고 다시 완료되는 과정을 계층별로 설명할 수 있어야 한다.
+
+```text
+Application / DBMS
+        ↓
+File system / Block layer
+        ↓
+NVMe driver
+        ↓
+PCIe: MMIO, DMA, MSI-X
+        ↓
+NVMe controller / Firmware
+        ↓
+FTL
+        ↓
+NAND Flash
+```
+
+# 1. 학습 방법
+
+하나의 주제를 처음부터 깊게 파기보다 전체 구조의 이론을 먼저 같은 깊이로 학습한다.
+
+그다음 동일한 I/O 경로를 코드, 측정, 장애 분석의 관점으로 반복해서 살펴본다.
+
+```text
+이론 지도
+  → 동작 흐름
+  → 실제 코드
+  → 성능 측정
+  → 장애 재현과 원인 분리
+```
+
+각 주제는 다음 질문에 답할 수 있을 때 다음 깊이로 넘어간다.
+
+1. 이것은 무엇인가?
+2. 왜 필요한가?
+3. 전체 I/O 경로의 어디에 있는가?
+4. 입력과 출력은 무엇인가?
+5. 어떤 구성 요소와 상호작용하는가?
+6. 정상 동작 순서는 어떻게 되는가?
+7. 어떤 오류와 병목이 발생할 수 있는가?
+8. 코드와 측정 결과에서는 어떻게 관찰할 수 있는가?
+
+# 2. 이미 학습한 기반 지식
+
+다음 주제는 처음부터 다시 공부하지 않고 기존 노트를 복습한 뒤 실험으로 확인한다.
+
+- CPU와 memory
+- Cache hierarchy
+- Cache coherence
+- Memory ordering
+- Virtual memory와 TLB
+- NUMA
+- Atomic operation
+- Memory barrier
+- Endianness와 alignment
+
+이 지식은 독립된 선행 과목이 아니라 device I/O를 이해하기 위한 기반이다.
+
+예를 들어 descriptor를 memory에 쓴 뒤 doorbell을 울리는 과정에는 cache, memory ordering, barrier가 다시 등장한다.
+
+IOMMU를 이해할 때는 virtual address와 address translation 지식이 필요하다.
+
+Multi-queue NVMe의 CPU affinity를 분석할 때는 cache locality와 NUMA 지식이 필요하다.
+
+# 3. 첫 번째 영역: CPU와 Device의 경계
+
+먼저 CPU가 device를 어떻게 제어하는지 이해한다.
+
+- Bus와 interconnect
+- Device controller
+- Device register
+- MMIO
+- Interrupt와 polling
+- Doorbell
+
+핵심 질문은 다음과 같다.
+
+```text
+CPU는 device에 어떻게 명령을 전달하는가?
+Device는 완료 사실을 CPU에 어떻게 알리는가?
+일반 memory와 device register는 무엇이 다른가?
+```
+
+# 4. 두 번째 영역: Data 이동
+
+다음으로 큰 payload가 CPU와 device 사이에서 이동하는 구조를 학습한다.
+
+- DMA
+- DMA mapping과 buffer lifetime
+- CPU virtual address, physical address, device-visible address
+- Coherent DMA와 non-coherent DMA
+- IOMMU
+- Descriptor와 ring buffer
+- Scatter-Gather I/O
+- Zero-copy
+- Memory barrier와 ownership
+
+이 영역의 중심 질문은 “현재 buffer와 descriptor의 소유자가 누구인가?”이다.
+
+CPU와 device가 같은 memory를 비동기적으로 사용하기 때문에 주소 변환, cache visibility, ordering, buffer 재사용 시점을 함께 이해해야 한다.
+
+# 5. 세 번째 영역: PCIe와 NVMe
+
+Device I/O의 공통 원리를 storage protocol에 연결한다.
+
+PCIe에서는 다음 항목을 학습한다.
+
+- Root Complex, endpoint, switch
+- Configuration space와 BAR
+- Link와 lane
+- Transaction과 completion
+- MSI와 MSI-X
+- AER와 오류 처리
+
+NVMe에서는 다음 항목을 학습한다.
+
+- Controller와 namespace
+- Admin Queue와 I/O Queue
+- Submission Queue와 Completion Queue
+- Doorbell과 phase tag
+- PRP와 SGL
+- Multi-queue와 interrupt affinity
+- Timeout, reset, error recovery
+
+# 6. 네 번째 영역: NAND와 FTL
+
+Host interface 아래에서 실제 media가 갖는 제약을 학습한다.
+
+NAND의 핵심 주제는 다음과 같다.
+
+- Cell, page, block
+- SLC, MLC, TLC, QLC
+- Page read/program과 block erase
+- Erase-before-write
+- ECC, bad block, retention, disturb
+- Channel, die, plane parallelism
+
+FTL의 핵심 주제는 다음과 같다.
+
+- Logical address와 physical address mapping
+- Out-of-place update
+- Garbage collection
+- Wear leveling
+- Over-provisioning
+- Write amplification
+- TRIM
+- Mapping recovery
+
+# 7. 이론 이후의 실습 방향
+
+전체 이론 지도를 완성한 뒤 다음 순서로 실습한다.
+
+## 7.1 Descriptor Ring Simulator
+
+Host thread가 descriptor를 생성하고 device thread가 소비하도록 구현한다.
+
+- Producer/consumer index
+- Ring wrap-around
+- Queue full과 backpressure
+- Descriptor ownership
+- Memory ordering
+- Polling과 notification 비교
+
+## 7.2 NVMe 관찰과 성능 분석
+
+Linux와 QEMU 또는 실제 NVMe 장비에서 다음 도구를 사용한다.
+
+- `lspci`
+- `nvme-cli`
+- `fio`
+- `iostat`
+- `perf`
+- Block tracepoint
+
+Block size, queue depth, read/write ratio와 access pattern을 바꾸면서 IOPS, bandwidth, average latency와 tail latency를 분석한다.
+
+## 7.3 FTL Simulator
+
+간단한 page-level mapping FTL을 구현한다.
+
+- Logical-to-physical mapping
+- Free block 관리
+- Garbage collection
+- Over-provisioning
+- Write amplification 측정
+- Power loss와 consistency test
+
+# 8. 직무별 최종 연결
+
+## Firmware Simulator·Test Platform
+
+정상 경로만 구현하는 것이 아니라 timeout, invalid descriptor, queue full, media error와 power loss를 주입한다.
+
+실패한 test를 random seed와 event log로 다시 재현할 수 있어야 한다.
+
+## Storage 성능 분석·Modeling
+
+DBMS에서 경험한 page, WAL, `fsync`, buffer와 concurrency 문제를 storage queue와 FTL의 동작에 연결한다.
+
+평균값만 보지 않고 p95, p99, p99.9 latency와 steady state를 함께 분석한다.
+
+## System Level 검증·호환성 분석
+
+오류를 다음 계층으로 나누어 조사한다.
+
+```text
+Application
+  → File system / Block layer
+  → Driver / PCIe
+  → Controller / Firmware
+  → FTL / NAND
+```
+
+각 실험에는 가설, 통제 변수, 재현 절차, 실제 결과, 증거와 다음 실험을 기록한다.
+
+# 정리
+
+학습의 기준은 읽은 문서의 수가 아니다.
+
+Application에서 NAND까지의 경로를 그리고, 각 경계에서 전달되는 명령, 주소, 데이터, 소유권과 완료 정보를 설명할 수 있어야 한다.
+
+전체 이론을 확립한 뒤 코드를 읽고 측정하면 개별 API와 수치가 어느 계층의 현상인지 판단할 수 있다.

--- a/_posts/2026-08-05-storage-io-end-to-end.md
+++ b/_posts/2026-08-05-storage-io-end-to-end.md
@@ -1,0 +1,319 @@
+---
+title: '[Storage] Application의 I/O는 NAND까지 어떻게 전달되는가'
+date: 2026-08-05 00:40:00 +09:00
+categories: [computer, storage]
+published: false
+tags:
+  [
+    storage stack,
+    NVMe,
+    PCIe,
+    FTL,
+    NAND
+  ]
+---
+
+# 개요
+
+Application이 file을 읽으면 SSD가 즉시 NAND page를 읽는 것처럼 보일 수 있다.
+
+실제로는 여러 software와 hardware 계층을 통과한다.
+
+```text
+Application / DBMS
+        ↓
+System Call
+        ↓
+File System / Page Cache
+        ↓
+Block Layer
+        ↓
+NVMe Driver
+        ↓
+PCIe
+        ↓
+NVMe Controller
+        ↓
+FTL
+        ↓
+NAND Flash
+```
+
+각 계층은 서로 다른 주소, queue와 완료 조건을 사용한다.
+
+Storage 성능과 오류를 분석하려면 “SSD가 느리다”는 하나의 결론보다 어느 계층에서 시간이 소비되었는지 분리해야 한다.
+
+# 1. Application과 System Call
+
+Application은 `read()`, `write()`, `pread()`, `fsync()` 또는 `io_uring` 같은 interface로 OS에 I/O를 요청한다.
+
+DBMS에서는 다음 동작이 storage I/O로 연결될 수 있다.
+
+- Data page read
+- Dirty page writeback
+- WAL write
+- Transaction commit의 `fsync`
+- Checkpoint
+
+Application의 요청 단위와 storage device의 처리 단위는 같지 않을 수 있다.
+
+DBMS page, file system block, block request, NVMe command와 NAND page를 구분해야 한다.
+
+# 2. File System과 Page Cache
+
+일반적인 buffered I/O는 page cache를 거칠 수 있다.
+
+Read 대상이 page cache에 있다면 device I/O 없이 memory에서 결과를 반환할 수 있다.
+
+```text
+Read Request
+    ├─ Page Cache Hit → Memory에서 반환
+    └─ Page Cache Miss → Block I/O 생성
+```
+
+Write도 application의 `write()`가 반환되는 시점과 data가 SSD에 영구적으로 기록되는 시점이 다를 수 있다.
+
+따라서 latency를 분석할 때 다음을 구분해야 한다.
+
+- Application이 system call을 완료한 시점
+- Kernel이 dirty page를 device에 제출한 시점
+- Device가 command를 완료한 시점
+- Durability가 보장되는 시점
+
+# 3. Block Layer
+
+Block layer는 file system의 I/O를 block device request로 변환하고 driver에 전달한다.
+
+주요 역할은 다음과 같다.
+
+- Request queue 관리
+- 인접 request의 merge
+- I/O scheduling
+- Queue depth와 backpressure 관리
+- Multi-queue를 통한 CPU별 request 분산
+- Completion을 상위 계층으로 전달
+
+NVMe 같은 multi-queue device에서는 Linux `blk-mq`와 hardware queue의 mapping이 성능에 영향을 줄 수 있다.
+
+# 4. NVMe Driver
+
+NVMe driver는 block request를 NVMe command로 만든다.
+
+```text
+Block Request
+    ↓
+NVMe Command 생성
+    ↓
+Submission Queue Entry 작성
+    ↓
+Data buffer를 PRP 또는 SGL로 표현
+    ↓
+Doorbell Write
+```
+
+Submission Queue와 Completion Queue는 host memory에 존재한다.
+
+Controller는 DMA를 이용해 command를 읽고 completion을 쓴다.
+
+# 5. PCIe
+
+PCIe는 host와 NVMe controller 사이의 통신 경로를 제공한다.
+
+이 경로에서는 서로 다른 종류의 transaction이 사용된다.
+
+- MMIO: Controller register와 doorbell 접근
+- DMA read: Controller가 command 또는 write payload를 host memory에서 읽음
+- DMA write: Controller가 read payload 또는 completion을 host memory에 기록
+- MSI-X: Completion event를 CPU에 알림
+
+PCIe link의 bandwidth만으로 SSD 성능이 결정되지는 않는다.
+
+Queueing, controller scheduling, NAND parallelism과 workload 특성도 함께 작용한다.
+
+# 6. NVMe Controller와 Firmware
+
+Controller는 제출된 command를 해석하고 내부 resource에 배치한다.
+
+```text
+NVMe Command Fetch
+    ↓
+Command Parsing
+    ↓
+FTL Mapping
+    ↓
+NAND Scheduling
+    ↓
+Data Transfer
+    ↓
+Completion 생성
+```
+
+여러 command가 동시에 들어오면 firmware는 channel, die와 queue 상태를 고려하여 처리 순서를 정할 수 있다.
+
+Host의 queue depth가 증가하면 device 내부 parallelism을 더 활용할 수 있지만 queueing delay도 증가할 수 있다.
+
+# 7. FTL
+
+Host는 LBA(Logical Block Address)로 storage에 접근한다.
+
+NAND는 page program과 block erase라는 제약을 가진다.
+
+FTL(Flash Translation Layer)은 host의 logical address를 NAND의 physical location으로 변환한다.
+
+```text
+Host LBA
+    ↓
+FTL Mapping Table
+    ↓
+Channel / Die / Block / Page
+```
+
+FTL은 단순 주소 변환 외에도 다음 작업을 수행한다.
+
+- Out-of-place update
+- Garbage collection
+- Wear leveling
+- Bad block 관리
+- Over-provisioning 관리
+- TRIM 처리
+- Mapping recovery
+
+# 8. NAND Flash
+
+NAND는 일반적으로 page 단위로 read/program하고 block 단위로 erase한다.
+
+```text
+Read     : Page 단위
+Program  : Page 단위
+Erase    : Block 단위
+```
+
+이미 program된 위치를 DRAM처럼 바로 덮어쓸 수 없다.
+
+새 위치에 data를 기록하고 기존 page를 invalid 처리한 뒤, 나중에 garbage collection으로 block을 정리한다.
+
+이 과정에서 host가 요청한 write보다 실제 NAND write가 많아질 수 있다.
+
+이를 write amplification이라고 한다.
+
+# 9. NVMe Read의 전체 흐름
+
+Page cache miss가 발생한 read를 예로 들면 다음과 같다.
+
+```text
+1. Application이 read 요청
+2. File system이 block I/O 생성
+3. Block layer가 NVMe driver에 request 전달
+4. Driver가 SQ entry와 PRP/SGL 작성
+5. Driver가 MMIO doorbell write
+6. Controller가 SQ entry를 DMA read
+7. FTL이 LBA를 NAND 위치로 mapping
+8. NAND page read
+9. Controller가 host buffer에 data를 DMA write
+10. Controller가 CQ entry를 DMA write
+11. MSI-X interrupt 또는 polling으로 completion 확인
+12. Driver와 block layer가 request 완료
+13. Application에 data 반환
+```
+
+# 10. NVMe Write의 전체 흐름
+
+Write에서는 data 방향과 durability 조건을 주의해야 한다.
+
+```text
+1. Application 또는 writeback이 write request 생성
+2. Driver가 SQ entry와 data buffer 정보 작성
+3. Controller가 host buffer의 data를 DMA read
+4. Firmware가 logical address의 새 physical location 결정
+5. NAND에 data program
+6. Mapping과 metadata 갱신
+7. Controller가 completion 기록
+8. Driver가 request 완료
+```
+
+Device cache, FUA, flush와 power-loss protection에 따라 command completion이 의미하는 durability 수준은 달라질 수 있다.
+
+“Write가 완료되었다”는 표현을 사용할 때 어느 계층의 완료인지 명확히 해야 한다.
+
+# 11. 주소의 종류
+
+전체 경로에는 여러 address space가 등장한다.
+
+| 주소 | 사용하는 주체 | 의미 |
+| --- | --- | --- |
+| Application virtual address | Process | Application buffer 위치 |
+| Kernel virtual address | Kernel | Kernel이 접근하는 mapping |
+| CPU physical address | CPU/Memory system | Physical memory 위치 |
+| DMA address | Device/IOMMU | Device가 DMA에 사용하는 주소 |
+| LBA | Host/Storage protocol | Logical block 위치 |
+| NAND physical location | Controller/FTL | Channel, die, block, page 위치 |
+
+이 주소들은 같은 숫자일 수도 있지만 같은 개념은 아니다.
+
+특히 DMA address를 CPU physical address와 항상 같다고 가정하면 IOMMU가 있는 환경을 이해할 수 없다.
+
+# 12. 성능 분석 관점
+
+End-to-end latency는 여러 구간의 합으로 볼 수 있다.
+
+```text
+Application/System Call
+  + File System/Page Cache
+  + Block Queueing
+  + Driver/PCIe
+  + Controller Queueing
+  + FTL/GC
+  + NAND Media
+  + Completion 전달
+```
+
+Queue depth를 늘리면 device parallelism을 활용해 throughput이 증가할 수 있다.
+
+하지만 요청이 queue에서 대기하는 시간이 늘어 tail latency가 악화될 수도 있다.
+
+따라서 다음 지표를 함께 확인해야 한다.
+
+- IOPS
+- Bandwidth
+- Average latency
+- p50, p95, p99, p99.9 latency
+- Queue depth
+- CPU 사용량
+- Read/write ratio
+- Sequential/random access pattern
+- Garbage collection과 write amplification
+
+# 13. 장애 분석 관점
+
+오류도 계층별로 분리한다.
+
+| 계층 | 확인할 문제 |
+| --- | --- |
+| Application/DBMS | 요청 pattern, timeout, durability 요구 |
+| File system/Block | Queueing, writeback, scheduling |
+| Driver | Descriptor, timeout, reset, buffer lifetime |
+| PCIe | Link, transaction, AER, MSI-X |
+| Controller/Firmware | Scheduling, command state, recovery |
+| FTL/NAND | Mapping, GC, bad block, media error |
+
+하나의 결과만으로 원인을 단정하지 않는다.
+
+가설을 세우고 관찰 지점을 추가하면서 문제가 시작되는 경계를 좁혀야 한다.
+
+# 정리
+
+Storage I/O는 하나의 함수 호출이 아니라 여러 software와 hardware 계층을 통과하는 비동기 작업이다.
+
+각 계층은 서로 다른 queue, address와 완료 조건을 사용한다.
+
+```text
+Application 요청
+  → OS가 block request 생성
+  → NVMe driver가 command 제출
+  → PCIe를 통해 controller와 통신
+  → FTL이 logical address 변환
+  → NAND가 실제 data 처리
+  → Completion이 반대 방향으로 전달
+```
+
+이 전체 경로를 먼저 이해하면 DMA, NVMe queue, FTL garbage collection과 tail latency를 서로 분리된 용어가 아니라 하나의 흐름으로 연결할 수 있다.

--- a/_posts/2026-08-06-cpu-memory-cache-hierarchy.md
+++ b/_posts/2026-08-06-cpu-memory-cache-hierarchy.md
@@ -1,0 +1,430 @@
+---
+title: '[CPU] Memory Access와 Cache Hierarchy'
+date: 2026-08-06 00:10:00 +09:00
+categories: [computer, CPU]
+published: false
+tags:
+  [
+    CPU,
+    memory,
+    cache hierarchy,
+    cache line,
+    locality
+  ]
+---
+
+# 개요
+
+CPU가 다음 instruction을 실행한다고 생각해보자.
+
+```c
+value = array[index];
+```
+
+소스 코드에는 memory read 한 번만 보인다.
+
+실제로는 virtual address 변환, cache tag 검색, cache miss 처리와 DRAM 접근이 필요할 수 있다.
+
+```text
+Load instruction
+  → Virtual address 생성
+  → Address translation
+  → L1 cache 검색
+  → L2 cache 검색
+  → Last-level cache 검색
+  → Memory controller
+  → DRAM
+```
+
+모든 단계가 항상 실행되는 것은 아니다.
+
+원하는 data가 가까운 cache에 있으면 아래 단계로 내려가지 않는다.
+
+이 글에서는 CPU와 memory의 속도 차이를 cache hierarchy가 어떻게 줄이는지 살펴본다.
+
+# 1. CPU와 Memory의 역할
+
+CPU core는 instruction을 가져오고 해석하고 실행한다.
+
+Memory는 실행할 instruction과 program이 사용하는 data를 저장한다.
+
+```text
+CPU
+  ├─ Instruction 실행
+  ├─ Register 연산
+  └─ Load/Store 요청
+
+Memory
+  ├─ Instruction 저장
+  └─ Data 저장
+```
+
+CPU의 일반적인 arithmetic instruction은 register를 대상으로 동작한다.
+
+Memory의 값을 계산하려면 먼저 load로 register에 가져오고, 결과를 memory에 남기려면 store를 수행한다.
+
+```text
+Memory → Load → Register → Operation → Register → Store → Memory
+```
+
+# 2. Register
+
+Register는 CPU core 내부에서 instruction이 직접 사용하는 작은 저장 공간이다.
+
+일반적으로 cache나 DRAM보다 빠르지만 개수가 제한되어 있다.
+
+Compiler는 program의 변수와 중간 결과를 가능한 한 register에 배치한다.
+
+Register가 부족하면 값을 stack memory 등에 잠시 저장하는 spill이 발생할 수 있다.
+
+# 3. CPU와 DRAM의 속도 차이
+
+CPU pipeline은 많은 instruction을 동시에 진행할 수 있다.
+
+반면 DRAM 접근은 CPU instruction 하나를 실행하는 것보다 훨씬 긴 시간이 걸릴 수 있다.
+
+CPU가 모든 load와 store마다 DRAM을 기다리면 pipeline이 자주 멈춘다.
+
+이를 memory wall 문제라고 부른다.
+
+Cache hierarchy는 자주 사용할 가능성이 높은 data를 CPU 가까이에 복사해 이 latency를 숨긴다.
+
+# 4. Locality
+
+Cache는 program의 memory access에 locality가 존재한다는 점을 이용한다.
+
+## 4.1 Temporal Locality
+
+최근 접근한 data를 다시 접근할 가능성이 높다는 성질이다.
+
+```c
+for (int i = 0; i < count; ++i) {
+    total += frequently_used_value;
+}
+```
+
+`frequently_used_value`는 반복해서 사용되므로 cache에 남겨두는 것이 유리하다.
+
+## 4.2 Spatial Locality
+
+접근한 주소 주변의 data를 곧 사용할 가능성이 높다는 성질이다.
+
+```c
+for (int i = 0; i < count; ++i) {
+    total += array[i];
+}
+```
+
+배열을 순서대로 읽으면 인접한 data를 계속 사용한다.
+
+Cache는 요청한 byte 하나가 아니라 주변 data를 포함하는 cache line 단위로 가져온다.
+
+# 5. Cache Hierarchy
+
+현대 CPU는 속도와 용량이 다른 여러 cache level을 사용한다.
+
+```text
+CPU Core
+  │
+  ├─ L1 Instruction Cache
+  ├─ L1 Data Cache
+  │
+  ▼
+L2 Cache
+  │
+  ▼
+Last-Level Cache
+  │
+  ▼
+Memory Controller
+  │
+  ▼
+DRAM
+```
+
+일반적인 성질은 다음과 같다.
+
+| 계층 | 위치와 성질 | 목적 |
+| --- | --- | --- |
+| Register | Core 내부, 가장 작음 | Instruction의 직접 operand |
+| L1 cache | Core에 가장 가까움 | 매우 낮은 latency |
+| L2 cache | L1보다 크고 느림 | L1 miss 흡수 |
+| Last-level cache | 여러 core가 공유할 수 있음 | DRAM 접근 감소 |
+| DRAM | 크지만 cache보다 느림 | Program의 main memory |
+
+정확한 cache 크기, 공유 방식과 latency는 CPU microarchitecture마다 다르다.
+
+Software가 특정 숫자를 보편적인 규칙처럼 가정하면 안 된다.
+
+# 6. Instruction Cache와 Data Cache
+
+L1 cache는 instruction과 data를 별도로 관리할 수 있다.
+
+- Instruction cache: CPU가 실행할 instruction 저장
+- Data cache: Load와 store가 사용하는 data 저장
+
+이 구조를 이용하면 instruction fetch와 data access를 병렬로 처리하기 쉽다.
+
+아래 단계에서는 instruction과 data가 통합된 cache를 사용할 수 있다.
+
+# 7. Cache Line
+
+Cache가 memory와 data를 주고받는 기본 단위를 cache line이라고 한다.
+
+예를 들어 cache line이 64 byte라면 `int` 하나를 읽더라도 주변 data가 함께 들어올 수 있다.
+
+```text
+Memory
+Address 0x1000 ───────────────── Address 0x103F
+          하나의 64-byte cache line
+```
+
+Cache line은 다음 현상을 설명하는 기준이다.
+
+- Spatial locality
+- Cache miss와 line fill
+- Cache coherence
+- False sharing
+- Alignment에 따른 line crossing
+
+# 8. Cache Hit와 Cache Miss
+
+CPU가 요청한 address의 cache line이 cache에 있으면 cache hit다.
+
+없으면 cache miss다.
+
+```text
+L1 lookup
+  ├─ Hit  → Data 반환
+  └─ Miss → L2 lookup
+               ├─ Hit  → L1에 채운 뒤 반환
+               └─ Miss → 다음 cache 또는 DRAM 접근
+```
+
+Cache miss는 원인에 따라 다음처럼 분류할 수 있다.
+
+## 8.1 Compulsory Miss
+
+해당 data에 처음 접근해 cache에 존재하지 않는 경우다.
+
+## 8.2 Capacity Miss
+
+Program의 working set이 cache 용량보다 커서 필요한 line이 밀려난 경우다.
+
+## 8.3 Conflict Miss
+
+Cache에 빈 공간이 있더라도 여러 address가 같은 cache set에 mapping되어 서로 밀어내는 경우다.
+
+Multi-core에서는 다른 core의 write로 line이 invalidate되어 발생하는 coherence miss도 고려해야 한다.
+
+# 9. Cache의 기본 구조
+
+Cache entry에는 data뿐 아니라 어떤 memory address의 data인지 나타내는 tag와 상태 정보가 필요하다.
+
+Address는 개념적으로 다음 영역으로 나뉜다.
+
+```text
++-----------+-----------+--------+
+| Tag       | Set Index | Offset |
++-----------+-----------+--------+
+```
+
+- Offset: cache line 안에서 원하는 byte 위치
+- Set index: 어느 cache set을 검색할지 결정
+- Tag: 해당 entry가 원하는 memory block인지 확인
+
+# 10. Direct-Mapped와 Set-Associative Cache
+
+Direct-mapped cache에서는 memory block이 들어갈 entry가 하나로 정해진다.
+
+구조는 단순하지만 같은 entry에 mapping되는 block끼리 자주 충돌할 수 있다.
+
+Set-associative cache에서는 하나의 set에 여러 way가 있다.
+
+```text
+Set 0: Way 0 | Way 1 | Way 2 | Way 3
+Set 1: Way 0 | Way 1 | Way 2 | Way 3
+```
+
+같은 set에 mapping되더라도 여러 block을 함께 보관할 수 있어 conflict miss를 줄인다.
+
+대신 여러 tag를 비교하고 replacement 대상을 선택해야 한다.
+
+# 11. Write Policy
+
+CPU의 store를 아래 cache와 memory에 언제 반영할지에 따라 정책이 나뉜다.
+
+## 11.1 Write-Through
+
+Cache를 변경할 때 아래 계층에도 즉시 write를 전달한다.
+
+구조는 비교적 단순하지만 write traffic이 많아질 수 있다.
+
+## 11.2 Write-Back
+
+먼저 cache line을 변경하고 dirty 상태로 표시한다.
+
+해당 line이 eviction될 때 아래 계층에 write back할 수 있다.
+
+Write traffic을 줄일 수 있지만 dirty line 관리가 필요하다.
+
+## 11.3 Write-Allocate와 No-Write-Allocate
+
+Store miss가 발생했을 때 line을 cache에 가져올지 결정하는 정책이다.
+
+- Write-allocate: line을 가져온 뒤 cache에서 수정
+- No-write-allocate: cache에 가져오지 않고 아래 계층으로 write 전달
+
+실제 조합은 cache level과 memory type에 따라 다를 수 있다.
+
+# 12. Cache Replacement
+
+Cache set이 가득 찬 상태에서 새 line을 넣으려면 기존 line을 선택해 내보내야 한다.
+
+이 결정을 replacement policy가 수행한다.
+
+정확한 LRU는 hardware 비용이 크기 때문에 실제 CPU는 pseudo-LRU나 다른 근사 정책을 사용할 수 있다.
+
+Software는 특정 replacement algorithm을 가정하기보다 working set과 access pattern을 관리해야 한다.
+
+# 13. Hardware Prefetcher
+
+CPU는 연속적이거나 반복적인 access pattern을 감지해 앞으로 필요할 data를 미리 cache에 가져올 수 있다.
+
+Sequential array traversal이 빠른 이유에는 spatial locality뿐 아니라 hardware prefetch도 포함될 수 있다.
+
+예측이 맞으면 latency를 숨기지만 불필요한 line을 가져오면 bandwidth와 cache 공간을 낭비할 수 있다.
+
+# 14. Load가 처리되는 흐름
+
+Load instruction의 전체 흐름을 단순화하면 다음과 같다.
+
+```text
+1. CPU가 effective virtual address 계산
+2. TLB를 이용해 physical address 확인
+3. L1 data cache의 set과 tag 검색
+4. Hit면 원하는 byte 반환
+5. Miss면 아래 cache 또는 DRAM에 line 요청
+6. 도착한 line을 cache에 채움
+7. 원하는 data를 load에 전달
+```
+
+Out-of-order CPU는 독립적인 다른 instruction을 실행해 miss latency를 숨길 수 있다.
+
+동시에 처리 가능한 miss 수에는 hardware resource의 한계가 있다.
+
+# 15. Store가 처리되는 흐름
+
+Store는 address와 data를 준비한 뒤 cache line의 쓰기 권한을 확보해야 한다.
+
+다른 core가 같은 line을 가지고 있다면 cache coherence transaction이 필요할 수 있다.
+
+CPU는 store buffer를 사용해 이 latency를 숨긴다.
+
+```text
+Store instruction
+  → Address와 data 계산
+  → Store buffer에 보관
+  → Cache line ownership 획득
+  → L1 cache 변경
+```
+
+Store instruction이 retire된 시점과 다른 core가 새 값을 관찰하는 시점, DRAM에 값이 기록되는 시점은 서로 다를 수 있다.
+
+# 16. Multi-Core와 Cache Coherence
+
+각 core가 동일한 memory의 cache copy를 가질 수 있다.
+
+한 core가 값을 변경할 때 다른 core가 오래된 값을 계속 사용하면 문제가 된다.
+
+Cache coherence protocol은 같은 cache line의 사본과 write ownership을 관리한다.
+
+```text
+Core A L1 ─┐
+           ├─ Coherence ─ Shared Cache / Memory
+Core B L1 ─┘
+```
+
+Cache coherence는 주로 같은 memory location의 값에 대한 일관성을 다룬다.
+
+여러 memory access가 어떤 순서로 관찰되는지는 memory ordering의 문제다.
+
+# 17. False Sharing
+
+두 thread가 서로 다른 변수를 변경해도 변수가 같은 cache line에 있으면 coherence traffic이 발생할 수 있다.
+
+```text
+하나의 cache line
++----------------+----------------+
+| Core A counter | Core B counter |
++----------------+----------------+
+```
+
+논리적으로 공유하지 않는 data가 cache line이라는 hardware 단위에서는 공유되는 현상을 false sharing이라고 한다.
+
+Data structure에 padding이나 alignment를 적용해 자주 변경하는 field를 다른 line으로 분리할 수 있다.
+
+다만 cache line 크기와 data locality, memory 사용량을 함께 고려해야 한다.
+
+# 18. 성능을 분석할 때 확인할 것
+
+Cache 성능은 단순히 “cache가 크면 빠르다”로 설명할 수 없다.
+
+다음 항목을 함께 확인해야 한다.
+
+- Working set 크기
+- Sequential 또는 random access
+- Read/write 비율
+- Cache line utilization
+- Data structure layout
+- Thread 간 data sharing
+- False sharing
+- NUMA 배치
+- TLB miss
+- Memory bandwidth
+
+# 19. 자주 생기는 오해
+
+## 19.1 Cache Hit면 한 cycle이다
+
+Cache level, access type, dependency와 CPU 구조에 따라 latency가 다르다.
+
+## 19.2 Cache는 Software가 직접 채운다
+
+일반적인 cacheable memory의 cache fill과 replacement는 hardware가 관리한다.
+
+Software는 access pattern, prefetch instruction과 cache policy를 통해 간접적으로 영향을 줄 수 있다.
+
+## 19.3 Cache Coherence가 Thread Synchronization을 해결한다
+
+Coherence는 cache copy의 일관성을 위한 기반이다.
+
+Program의 data race를 없애거나 필요한 memory ordering을 자동으로 표현하지 않는다.
+
+언어의 atomic과 lock 같은 synchronization이 별도로 필요하다.
+
+## 19.4 Cache의 최종 목적지는 항상 DRAM이다
+
+일반 cacheable memory에서는 보통 DRAM이 backing store다.
+
+하지만 MMIO와 persistent memory처럼 memory type과 목적지가 다른 access도 있으므로 address space의 모든 영역을 일반 DRAM처럼 취급하면 안 된다.
+
+# 정리
+
+CPU는 register에서 연산하고 load와 store를 통해 memory에 접근한다.
+
+CPU와 DRAM의 속도 차이를 줄이기 위해 여러 단계의 cache hierarchy를 사용한다.
+
+```text
+Register
+  → L1 Cache
+  → L2 Cache
+  → Last-Level Cache
+  → DRAM
+```
+
+Cache는 locality를 이용하고 cache line 단위로 data를 관리한다.
+
+Multi-core 환경에서는 cache line의 사본과 write ownership을 cache coherence protocol이 조정한다.
+
+다음 글에서는 load가 사용하는 virtual address가 physical memory의 위치로 어떻게 변환되는지 살펴본다.

--- a/_posts/2026-08-06-endianness-alignment.md
+++ b/_posts/2026-08-06-endianness-alignment.md
@@ -1,0 +1,359 @@
+---
+title: '[Computer Architecture] Endianness와 Alignment'
+date: 2026-08-06 00:30:00 +09:00
+categories: [computer, architecture]
+published: false
+tags:
+  [
+    endianness,
+    alignment,
+    padding,
+    data layout,
+    ABI
+  ]
+---
+
+# 개요
+
+Memory는 address가 붙은 byte의 배열로 볼 수 있다.
+
+하지만 program은 2 byte, 4 byte, 8 byte처럼 여러 byte로 구성된 값을 사용한다.
+
+```c
+uint32_t value = 0x12345678;
+```
+
+이 값을 memory의 네 byte에 어떤 순서로 저장할지를 endianness가 결정한다.
+
+값을 어느 address 경계에 배치할지를 alignment가 결정한다.
+
+두 개념은 binary file, network protocol, MMIO register, DMA descriptor와 C structure layout을 이해하는 데 필요하다.
+
+# 1. Byte와 Multi-Byte Value
+
+Memory의 각 address는 일반적으로 한 byte를 가리킨다.
+
+32-bit 정수는 연속된 네 byte를 사용한다.
+
+```text
+Address A     : 1 byte
+Address A + 1 : 1 byte
+Address A + 2 : 1 byte
+Address A + 3 : 1 byte
+```
+
+문제는 정수의 가장 중요한 byte와 가장 덜 중요한 byte를 어느 address에 놓을지다.
+
+# 2. Big-Endian과 Little-Endian
+
+`0x12345678`을 address `0x1000`부터 저장한다고 생각해보자.
+
+## 2.1 Big-Endian
+
+가장 중요한 byte인 `0x12`를 가장 낮은 address에 저장한다.
+
+```text
+Address   Value
+0x1000    0x12
+0x1001    0x34
+0x1002    0x56
+0x1003    0x78
+```
+
+## 2.2 Little-Endian
+
+가장 덜 중요한 byte인 `0x78`을 가장 낮은 address에 저장한다.
+
+```text
+Address   Value
+0x1000    0x78
+0x1001    0x56
+0x1002    0x34
+0x1003    0x12
+```
+
+Endianness는 byte의 bit 순서를 뒤집는 개념이 아니다.
+
+Multi-byte value를 구성하는 byte들의 memory 배치 순서를 의미한다.
+
+# 3. Register의 숫자와 Memory Layout
+
+CPU register에서 `0x12345678`이라는 숫자의 의미가 endianness에 따라 달라지는 것은 아니다.
+
+차이는 이 값을 memory에 저장하거나 memory에서 다시 조합할 때 나타난다.
+
+```text
+Register value: 0x12345678
+       ↓ store
+Memory bytes: architecture의 byte order에 따라 배치
+```
+
+# 4. Network Byte Order
+
+서로 다른 endianness를 사용하는 system이 binary integer를 그대로 주고받으면 값을 다르게 해석할 수 있다.
+
+Network protocol은 multi-byte integer의 byte order를 명시해야 한다.
+
+전통적인 network byte order는 big-endian이다.
+
+```c
+uint32_t network_value = htonl(host_value);
+uint32_t host_value = ntohl(network_value);
+```
+
+Protocol의 field를 처리할 때 host architecture의 endianness를 가정하지 않고 명시적인 encode/decode를 수행해야 한다.
+
+# 5. Binary File과 Storage Format
+
+Binary file format도 integer field의 byte order를 정의해야 한다.
+
+다음 구조체를 그대로 file에 쓰는 방식은 이식성이 낮다.
+
+```c
+struct header {
+    uint16_t version;
+    uint32_t length;
+};
+```
+
+문제는 endianness만이 아니다.
+
+- Compiler가 삽입한 padding
+- Type size
+- Alignment
+- ABI
+- Structure layout
+
+Portable format은 field별 byte order와 width를 명시하고 직접 serialize해야 한다.
+
+# 6. MMIO와 Endianness
+
+Device register가 정의하는 byte order와 CPU의 native byte order가 다를 수 있다.
+
+Driver는 specification과 OS accessor가 제공하는 변환 규칙을 따라야 한다.
+
+```text
+CPU Native Value
+    ↓ 필요하면 byte-order 변환
+Bus / Device Register Representation
+```
+
+Register를 단순 C pointer로 읽고 host integer처럼 해석하면 architecture에 따라 잘못된 결과가 생길 수 있다.
+
+# 7. Alignment
+
+Alignment는 object의 시작 address가 만족해야 하는 경계 조건이다.
+
+예를 들어 4-byte alignment는 시작 address가 4의 배수여야 한다는 뜻이다.
+
+```text
+Aligned address:   0x1000, 0x1004, 0x1008
+Unaligned address: 0x1001, 0x1002, 0x1003
+```
+
+C에서는 `_Alignof` 또는 `alignof`로 type의 alignment requirement를 확인할 수 있다.
+
+```c
+#include <stdalign.h>
+#include <stdio.h>
+
+printf("%zu\n", alignof(uint64_t));
+```
+
+# 8. Alignment가 필요한 이유
+
+Hardware는 정렬된 access를 더 단순하고 효율적으로 처리할 수 있다.
+
+하나의 access가 자연스러운 boundary를 넘으면 여러 memory transaction이 필요할 수 있다.
+
+```text
+Aligned 8-byte access
++-----------------------+
+|       8 bytes         |
++-----------------------+
+
+Unaligned 8-byte access
+       +-----------------------+
+Line A | part 1                |
+       +-----------+-----------+
+Line B             | part 2    |
+                   +-----------+
+```
+
+특히 cache line이나 page boundary를 넘으면 추가 cache line 접근 또는 page translation이 필요할 수 있다.
+
+# 9. Unaligned Access
+
+Unaligned access의 동작은 architecture와 instruction에 따라 다르다.
+
+- Hardware가 처리하지만 더 느릴 수 있음
+- 여러 access로 분할될 수 있음
+- 특정 instruction에서 fault가 발생할 수 있음
+- Device register에서는 허용되지 않을 수 있음
+- Atomicity 보장이 깨질 수 있음
+
+“x86에서는 unaligned access가 가능하다”는 사실을 모든 architecture와 모든 memory type에 일반화하면 안 된다.
+
+# 10. Structure Padding
+
+Compiler는 각 field의 alignment와 structure 자체의 alignment를 맞추기 위해 field 사이와 끝에 padding을 넣을 수 있다.
+
+```c
+struct example {
+    uint8_t  type;
+    uint32_t length;
+    uint16_t flags;
+};
+```
+
+개념적인 layout은 다음과 같을 수 있다.
+
+```text
++------+---------+--------+-------+--------------+
+| type | padding | length | flags | tail padding |
++------+---------+--------+-------+--------------+
+```
+
+정확한 layout은 ABI와 compiler 규칙에 따라 결정된다.
+
+`sizeof(struct example)`이 field 크기의 단순 합과 같다고 가정하면 안 된다.
+
+# 11. Field 순서와 Memory 사용량
+
+Field 순서를 바꾸면 padding을 줄일 수 있다.
+
+```c
+struct compact_example {
+    uint32_t length;
+    uint16_t flags;
+    uint8_t  type;
+};
+```
+
+하지만 다음 사항도 함께 고려해야 한다.
+
+- ABI 또는 file format 호환성
+- Cache locality
+- 자주 함께 접근하는 field
+- False sharing
+- 외부 protocol이 요구하는 layout
+
+단순히 `sizeof`를 줄이는 것이 항상 최적은 아니다.
+
+# 12. Packed Structure
+
+Compiler extension이나 attribute로 padding을 제거할 수 있다.
+
+그러나 packed structure의 field는 unaligned address에 놓일 수 있다.
+
+```text
+Padding 감소
+  ↔ Unaligned access와 portability 문제 증가
+```
+
+Hardware descriptor나 protocol header를 표현할 때 packed structure를 사용할 수 있지만 specification, compiler behavior와 access 방법을 확인해야 한다.
+
+Portable code에서는 byte buffer와 명시적인 encode/decode가 더 안전할 수 있다.
+
+# 13. Alignment와 Atomic Operation
+
+Atomic type은 구현이 요구하는 alignment를 만족해야 한다.
+
+Misaligned atomic object는 언어 규칙을 위반하거나 hardware가 하나의 atomic transaction으로 처리할 수 없을 수 있다.
+
+```text
+Aligned atomic access
+  → 하나의 자연스러운 hardware 단위로 처리 가능
+
+Misaligned atomic access
+  → 여러 boundary를 넘을 수 있음
+  → atomicity 또는 지원 여부 문제
+```
+
+`memcpy`나 packed buffer 안의 byte를 atomic pointer로 강제 변환하면 alignment와 object lifetime 문제를 함께 만들 수 있다.
+
+# 14. Alignment와 Cache Line
+
+Alignment는 correctness뿐 아니라 성능에도 사용된다.
+
+## 14.1 False Sharing 방지
+
+서로 다른 thread가 자주 변경하는 값을 별도 cache line에 배치할 수 있다.
+
+```c
+struct counter {
+    alignas(64) atomic_uint_fast64_t value;
+};
+```
+
+실제 cache line size와 object 배열의 layout을 확인해야 한다.
+
+## 14.2 SIMD와 DMA
+
+일부 vector instruction, DMA engine 또는 device descriptor는 특정 alignment를 요구하거나 정렬된 buffer에서 더 효율적으로 동작할 수 있다.
+
+요구 조건은 architecture와 device specification을 따라야 한다.
+
+# 15. Alignment와 Page Boundary
+
+Buffer가 page boundary를 넘으면 하나의 논리적 buffer가 여러 physical page에 mapping될 수 있다.
+
+Device가 연속적인 physical memory만 지원한다면 문제가 될 수 있다.
+
+Scatter-gather와 IOMMU는 여러 physical page를 device가 처리할 수 있는 형태로 표현하거나 mapping하는 데 사용될 수 있다.
+
+# 16. 안전한 Binary Decode
+
+외부에서 받은 byte buffer를 structure pointer로 강제 변환하는 방식은 다음 문제를 가질 수 있다.
+
+```c
+const struct header *header = (const struct header *)buffer;
+```
+
+- Buffer alignment가 structure 요구사항을 만족하지 않을 수 있음
+- Endianness가 다를 수 있음
+- Buffer 길이가 부족할 수 있음
+- Structure padding이 protocol layout과 다를 수 있음
+- Strict aliasing과 object representation 문제
+
+안전한 접근은 길이를 먼저 검사하고 byte를 명시적으로 decode하거나 적절한 임시 object에 `memcpy`한 뒤 byte order를 변환하는 것이다.
+
+# 17. 자주 생기는 오해
+
+## 17.1 Little-Endian은 bit 순서를 뒤집는다
+
+Endianness는 multi-byte value를 구성하는 byte의 address 순서다.
+
+## 17.2 Structure 크기는 field 크기의 합이다
+
+Alignment를 위한 padding이 포함될 수 있다.
+
+## 17.3 Packed를 사용하면 항상 효율적이다
+
+Memory 크기는 줄어도 unaligned access와 portability 비용이 생길 수 있다.
+
+## 17.4 Unaligned Access가 가능한 CPU에서는 신경 쓰지 않아도 된다
+
+성능, atomicity, SIMD, MMIO와 다른 architecture 호환성을 고려해야 한다.
+
+## 17.5 Endianness는 Network에서만 필요하다
+
+Binary file, device register, DMA descriptor, storage metadata와 cross-platform data exchange에도 필요하다.
+
+# 정리
+
+Endianness는 multi-byte value의 byte 배치 순서를 정의한다.
+
+Alignment는 object를 배치하고 접근할 address 경계를 정의한다.
+
+```text
+Endianness
+  → Byte를 어떤 순서로 해석하는가
+
+Alignment
+  → Value를 어느 address 경계에 배치하는가
+```
+
+두 개념은 C structure, protocol, binary file과 device interface를 연결할 때 함께 확인해야 한다.
+
+다음 글에서는 memory access 시간이 CPU와 memory의 물리적 위치에 따라 달라지는 NUMA 구조를 살펴본다.

--- a/_posts/2026-08-06-memory-system-reading-order.md
+++ b/_posts/2026-08-06-memory-system-reading-order.md
@@ -1,0 +1,277 @@
+---
+title: '[Memory System] CPU부터 NVMe·NAND까지 읽는 순서'
+date: 2026-08-06 00:50:00 +09:00
+categories: [computer, memory]
+published: false
+tags:
+  [
+    memory system,
+    CPU,
+    atomic,
+    device I/O,
+    NVMe,
+    study guide
+  ]
+---
+
+# 개요
+
+CPU, cache, atomic, DMA, NVMe와 NAND는 서로 독립적인 주제가 아니다.
+
+CPU가 memory를 읽고 쓰는 원리에서 시작해 여러 core의 동기화, CPU와 device의 비동기 통신, storage media의 동작으로 확장된다.
+
+```text
+CPU와 Memory
+    ↓
+Cache와 Address Translation
+    ↓
+Multi-Core 동기화
+    ↓
+CPU와 Device I/O
+    ↓
+PCIe와 NVMe
+    ↓
+FTL과 NAND
+```
+
+이 글은 블로그에 정리한 내용을 의존 관계에 따라 읽기 위한 안내서다.
+
+# 1. 전체 흐름 먼저 보기
+
+가장 먼저 다음 글을 읽어 전체 학습 범위와 application에서 NAND까지 이어지는 경로를 확인한다.
+
+1. `[Memory System] 삼성전자 메모리사업부 지원을 위한 학습 로드맵`
+2. [[Storage] Application의 I/O는 NAND까지 어떻게 전달되는가](/posts/storage-io-end-to-end/)
+
+로드맵은 `_posts/2026-08-05-memory-system-storage-study-roadmap.md`에 있으며 현재 `published: false`로 설정되어 있다. 공개 전에도 source 문서로 먼저 읽을 수 있다.
+
+첫 단계에서는 PCIe, DMA, FTL의 세부 내용을 모두 이해할 필요는 없다.
+
+각 용어가 전체 경로의 어느 위치에 있는지만 확인한다.
+
+# 2. CPU와 Memory의 기본 구조
+
+## 2.1 Memory Access와 Cache
+
+3. [[CPU] Memory Access와 Cache Hierarchy](/posts/cpu-memory-cache-hierarchy/)
+
+다음 내용을 확인한다.
+
+- CPU가 register, load와 store를 사용하는 방식
+- CPU와 DRAM의 속도 차이
+- Locality
+- L1/L2/last-level cache
+- Cache line, hit와 miss
+- Write policy
+- Multi-core cache의 기본 문제
+
+완료 기준:
+
+> Load가 L1 cache에서 miss한 뒤 아래 cache와 DRAM을 거쳐 data를 가져오는 과정을 설명할 수 있다.
+
+## 2.2 Virtual Memory와 TLB
+
+4. [[Memory] Virtual Memory와 TLB](/posts/virtual-memory-tlb/)
+
+다음 개념을 연결한다.
+
+```text
+Virtual Address
+  → TLB
+  → Page Table
+  → Physical Address
+  → Cache / Memory
+```
+
+완료 기준:
+
+> TLB miss와 page fault의 차이를 설명하고, application virtual address와 device DMA address가 다른 이유를 말할 수 있다.
+
+## 2.3 Data Layout
+
+5. [[Computer Architecture] Endianness와 Alignment](/posts/endianness-alignment/)
+
+Binary data, C structure, MMIO register와 DMA descriptor를 읽기 위한 기반이다.
+
+완료 기준:
+
+> Endianness와 alignment를 구분하고 structure를 그대로 protocol이나 file에 저장하면 위험한 이유를 설명할 수 있다.
+
+## 2.4 Memory Locality
+
+6. [[Memory] NUMA 구조와 Local·Remote Memory](/posts/numa-memory-architecture/)
+
+완료 기준:
+
+> CPU affinity만으로 NUMA locality가 보장되지 않는 이유와 NVMe queue·interrupt·DMA buffer의 위치가 중요한 이유를 설명할 수 있다.
+
+# 3. Atomic Operation과 Cache Coherence
+
+기본 memory 구조를 이해한 뒤 여러 thread가 같은 data를 사용할 때의 문제로 이동한다.
+
+## 3.1 Atomic이 필요한 이유
+
+7. [[C언어] Atomic Operation 1. 왜 Atomic이 필요한가](/posts/c-atomic-operation-1/)
+
+다음 순서로 이해한다.
+
+```text
+counter++
+  → 여러 단계의 read-modify-write
+  → Race condition과 lost update
+  → C의 data race
+  → Atomic operation
+```
+
+## 3.2 C Atomic API
+
+8. [[C언어] Atomic Operation 2. stdatomic.h 사용법](/posts/c-atomic-operation-2/)
+
+`atomic_load`, `atomic_store`, `atomic_fetch_add`, `atomic_exchange`와 compare-exchange의 기본 사용법을 확인한다.
+
+이 시점에는 모든 memory order를 외우지 않는다.
+
+## 3.3 Hardware Atomic과 Cache Coherence
+
+9. [[C언어] Atomic Operation 3. Atomic은 실제로 어떻게 동작하는가](/posts/c-atomic-operation-3/)
+
+C의 atomic 보장이 x86-64와 ARM64 instruction, cache line ownership과 coherence protocol로 연결되는 과정을 읽는다.
+
+완료 기준:
+
+> Atomicity와 “CPU instruction 하나”가 같은 뜻이 아닌 이유, 서로 다른 변수가 false sharing을 일으키는 이유를 설명할 수 있다.
+
+# 4. Store Buffer와 Memory Ordering
+
+## 4.1 Store Buffer
+
+10. [[CPU] Store Buffer는 어떻게 동작하는가](/posts/cpu-store-buffer/)
+
+다음 시점을 구분한다.
+
+```text
+Store instruction 실행
+  → Retire
+  → Store buffer drain
+  → 다른 core에서 관찰 가능
+  → Dirty line의 DRAM write-back
+```
+
+이 글에서 store-to-load forwarding, store buffering litmus test와 barrier의 hardware 배경을 먼저 이해한다.
+
+## 4.2 C Memory Ordering
+
+11. [[C언어] Atomic Operation 4. Memory Order 이해하기](/posts/c-atomic-operation-4/)
+
+다음 개념을 순서대로 읽는다.
+
+- Atomicity와 ordering의 차이
+- Happens-before
+- Relaxed
+- Release와 acquire
+- Acquire-release
+- Sequential consistency
+- Atomic fence
+
+완료 기준:
+
+> Producer가 data를 쓴 뒤 release store로 flag를 publish하고 consumer가 acquire load로 data를 안전하게 읽는 이유를 설명할 수 있다.
+
+## 4.3 Atomic과 Lock
+
+12. [[C언어] Atomic Operation 5. Atomic과 Mutex 비교하기](/posts/c-atomic-operation-5/)
+
+Atomic, mutex와 spinlock은 단순한 속도 비교 대상이 아니다.
+
+보호할 불변식의 범위, critical section 길이, 경합과 scheduler 동작을 기준으로 선택하는 방법을 확인한다.
+
+## 4.4 특수한 Cache 접근
+
+13. [What Every Programmer Should Know About Memory - Chapter6.1 Bypassing the Cache](/posts/BypassingTheCache/)
+
+일반 cacheable memory access를 이해한 뒤 non-temporal load/store, write-combining과 barrier를 살펴본다.
+
+이 내용은 특수한 최적화이므로 일반 memory access보다 먼저 적용하지 않는다.
+
+# 5. CPU와 Device의 통신
+
+CPU 내부와 multi-core 동기화를 이해한 뒤 device I/O로 이동한다.
+
+## 5.1 Bus, Register와 MMIO
+
+14. [[Device I/O] CPU는 Device와 어떻게 통신하는가](/posts/cpu-device-communication/)
+
+완료 기준:
+
+> Device register와 일반 RAM의 차이, MMIO access에 `volatile`만으로 충분하지 않은 이유, descriptor를 완성한 뒤 doorbell을 써야 하는 이유를 설명할 수 있다.
+
+## 5.2 Interrupt, Polling과 DMA
+
+15. [[Device I/O] Interrupt와 Polling, DMA는 어떻게 연결되는가](/posts/interrupt-polling-dma/)
+
+다음 두 질문을 구분한다.
+
+```text
+DMA: Payload를 누가 이동하는가?
+Interrupt/Polling: CPU가 완료를 어떻게 발견하는가?
+```
+
+완료 기준:
+
+> Driver가 buffer를 준비하고 device가 DMA를 수행한 뒤 interrupt 또는 polling으로 완료를 처리하는 lifecycle을 설명할 수 있다.
+
+# 6. Storage Firmware와 성능 분석
+
+16. `[Storage] Firmware Simulator·Test Platform과 성능 분석·Modeling 입문`
+
+이 글에서는 NAND, FTL, NVMe queue, simulator와 성능 modeling을 직무 관점으로 연결한다.
+
+이 글은 `_posts/2026-08-02-storage-firmware-simulator-performance-modeling.md`에 정리되어 있다. 현재 `published: false`로 설정되어 있으므로 블로그에서 공개하려면 내용을 최종 검토한 뒤 설정을 변경해야 한다.
+
+# 7. 읽으면서 사용할 질문
+
+모든 글을 읽은 뒤 다음 질문에 자신의 문장으로 답한다.
+
+## CPU와 Memory
+
+1. Cache line이 필요한 이유는 무엇인가?
+2. Cache coherence와 memory ordering은 무엇이 다른가?
+3. TLB miss와 page fault는 무엇이 다른가?
+4. Huge page의 장점과 비용은 무엇인가?
+5. NUMA에서 CPU, memory와 device locality를 함께 봐야 하는 이유는 무엇인가?
+
+## Concurrency
+
+6. `counter++`가 atomic하지 않은 이유는 무엇인가?
+7. Atomicity와 visibility, ordering은 무엇이 다른가?
+8. Release-acquire는 어떤 data를 안전하게 publish하는가?
+9. Memory barrier는 cache 전체를 flush하는 명령인가?
+10. Atomic 대신 mutex가 필요한 상황은 무엇인가?
+
+## Device I/O와 Storage
+
+11. MMIO register와 일반 memory는 무엇이 다른가?
+12. DMA에서 CPU, driver와 device의 역할은 각각 무엇인가?
+13. Descriptor write와 doorbell write 사이에 ordering이 필요한 이유는 무엇인가?
+14. Interrupt와 polling의 trade-off는 무엇인가?
+15. NVMe read command가 application에서 NAND까지 이동하고 완료되는 순서는 무엇인가?
+
+# 8. 전체 완료 기준
+
+다음 흐름을 보지 않고 직접 그릴 수 있으면 이론의 첫 번째 순회가 완료된 것이다.
+
+```text
+Application Virtual Address
+  → Page Table / TLB
+  → CPU Cache Hierarchy
+  → Driver의 Descriptor
+  → MMIO Doorbell
+  → Device의 DMA
+  → PCIe / NVMe Controller
+  → FTL Mapping
+  → NAND
+  → DMA Completion
+  → MSI-X Interrupt 또는 Polling
+```
+
+이후에는 같은 순서를 실제 driver 코드, simulator와 benchmark로 다시 확인한다.

--- a/_posts/2026-08-06-numa-memory-architecture.md
+++ b/_posts/2026-08-06-numa-memory-architecture.md
@@ -1,0 +1,307 @@
+---
+title: '[Memory] NUMA 구조와 Local·Remote Memory'
+date: 2026-08-06 00:40:00 +09:00
+categories: [computer, memory]
+published: false
+tags:
+  [
+    NUMA,
+    memory locality,
+    CPU affinity,
+    memory bandwidth,
+    PCIe
+  ]
+---
+
+# 개요
+
+Multi-core system에서 모든 CPU가 모든 memory에 같은 비용으로 접근한다고 생각하기 쉽다.
+
+하지만 여러 CPU socket이나 memory node로 구성된 system에서는 memory의 위치에 따라 latency와 bandwidth가 달라질 수 있다.
+
+이를 NUMA(Non-Uniform Memory Access)라고 한다.
+
+```text
+CPU가 가까운 Memory 접근  → Local Memory Access
+CPU가 다른 Node의 Memory 접근 → Remote Memory Access
+```
+
+NUMA는 database, high-performance server와 multi-queue storage의 성능을 분석할 때 중요하다.
+
+# 1. UMA
+
+UMA(Uniform Memory Access) model에서는 모든 CPU가 memory에 접근하는 비용이 대체로 동일하다고 본다.
+
+```text
+CPU 0 ─┐
+CPU 1 ─┼─ Shared Memory Controller ─ Memory
+CPU 2 ─┤
+CPU 3 ─┘
+```
+
+CPU 수가 증가하면 하나의 memory controller와 interconnect가 병목이 될 수 있다.
+
+# 2. NUMA
+
+NUMA system은 CPU와 memory resource를 여러 node로 나눈다.
+
+```text
++----------------------+        +----------------------+
+| NUMA Node 0          |        | NUMA Node 1          |
+| CPU 0, CPU 1         |        | CPU 2, CPU 3         |
+| Memory Controller 0  |<------>| Memory Controller 1  |
+| Local Memory 0       |        | Local Memory 1       |
++----------------------+        +----------------------+
+```
+
+CPU 0이 Memory 0에 접근하면 local access다.
+
+CPU 0이 Memory 1에 접근하면 node 사이의 interconnect를 거치는 remote access다.
+
+일반적으로 remote access는 추가 latency와 interconnect traffic을 발생시킬 수 있다.
+
+# 3. NUMA Node
+
+NUMA node는 가까운 CPU와 memory resource의 집합이다.
+
+System에 따라 node에는 다음 resource가 연결될 수 있다.
+
+- CPU core
+- Memory controller와 memory
+- PCIe Root Complex
+- Network 또는 storage device
+
+정확한 topology는 hardware와 firmware, OS 설정에 따라 달라진다.
+
+# 4. Local과 Remote Memory Access
+
+Thread가 실행 중인 CPU와 memory page가 같은 node에 있으면 local access다.
+
+다른 node에 있으면 remote access다.
+
+```text
+Thread on CPU 0
+  ├─ Node 0 Memory → Local
+  └─ Node 1 Memory → Remote interconnect 경유
+```
+
+Remote access의 영향은 workload에 따라 다르다.
+
+- Pointer chasing처럼 dependency가 강한 workload: latency 영향이 큼
+- Sequential streaming workload: bandwidth와 interconnect 경쟁이 중요
+- Cache hit가 많은 workload: memory node 차이가 덜 드러날 수 있음
+- Shared writable data: cache coherence traffic도 함께 발생
+
+# 5. CPU Affinity
+
+OS scheduler는 thread를 다른 CPU로 이동시킬 수 있다.
+
+Thread가 이동해도 이미 할당된 memory page의 node가 자동으로 함께 이동하는 것은 아니다.
+
+```text
+처음: Thread CPU 0 + Memory Node 0
+이동: Thread CPU 3 + Memory Node 0
+                      ↑ remote access 가능
+```
+
+CPU affinity를 사용하면 thread가 실행할 CPU 집합을 제한할 수 있다.
+
+하지만 CPU만 고정하고 memory placement를 고려하지 않으면 NUMA locality가 보장되지 않는다.
+
+# 6. Memory Placement
+
+OS는 physical page를 어느 NUMA node에 할당할지 policy를 사용한다.
+
+대표적인 개념은 다음과 같다.
+
+- Local allocation: 요청한 CPU와 가까운 node에서 할당
+- Preferred node: 특정 node를 우선 사용
+- Bind: 지정한 node 집합에서만 할당
+- Interleave: 여러 node에 page를 분산
+
+구체적인 policy 이름과 동작은 OS를 확인해야 한다.
+
+# 7. First-Touch Policy
+
+Linux 같은 system에서는 anonymous memory의 physical page가 처음 실제로 접근되는 시점에 할당되는 first-touch 정책이 사용될 수 있다.
+
+```c
+void *buffer = allocate_large_buffer();
+
+// 어느 CPU의 thread가 page를 처음 write하는지에 따라
+// physical page의 NUMA node가 결정될 수 있다.
+initialize_buffer(buffer);
+```
+
+Main thread 하나가 전체 buffer를 초기화한 뒤 여러 worker가 다른 node에서 사용하면 page가 한 node에 몰릴 수 있다.
+
+각 worker가 자신이 사용할 영역을 자신의 CPU에서 먼저 초기화하면 local allocation을 유도할 수 있다.
+
+# 8. Cache Coherence와 NUMA
+
+NUMA와 cache coherence는 다른 문제지만 함께 작동한다.
+
+- NUMA: Physical memory와 CPU의 거리
+- Cache coherence: 여러 cache에 존재하는 같은 line의 사본과 write ownership
+
+서로 다른 node의 thread가 같은 cache line을 자주 변경하면 remote memory access뿐 아니라 node 사이의 coherence traffic도 증가할 수 있다.
+
+```text
+Node 0 Core가 Line X write
+    ↔ Interconnect를 통한 ownership 이동
+Node 1 Core가 Line X write
+```
+
+False sharing이 NUMA node 사이에서 발생하면 비용이 더 크게 나타날 수 있다.
+
+# 9. NUMA와 Database
+
+Database는 큰 buffer pool과 많은 worker thread를 사용하므로 NUMA의 영향을 받을 수 있다.
+
+확인할 항목:
+
+- Buffer pool page가 어느 node에 배치되는가
+- Query worker와 data의 node가 일치하는가
+- Lock과 shared counter가 node 사이에서 경쟁하는가
+- Background thread가 어느 CPU에서 동작하는가
+- Memory bandwidth가 특정 node에 몰리는가
+- Huge page와 first-touch가 어떻게 결합되는가
+
+모든 memory를 한 node에 두면 일부 access는 local해지지만 해당 node의 capacity와 bandwidth가 병목이 될 수 있다.
+
+Interleave는 bandwidth를 분산할 수 있지만 모든 access를 local로 만들지는 않는다.
+
+# 10. NUMA와 PCIe Device
+
+PCIe device도 특정 CPU socket 또는 NUMA node의 Root Complex에 가까울 수 있다.
+
+```text
+Node 0 CPU / Memory / PCIe Root Complex
+                    │
+                    └─ NVMe SSD
+
+Node 1 CPU / Memory
+```
+
+Node 1의 thread가 Node 0에 연결된 NVMe를 사용하고 buffer도 Node 1에 있다면 command 처리, DMA와 completion 과정에서 node 간 traffic이 발생할 수 있다.
+
+# 11. NVMe Multi-Queue와 NUMA
+
+NVMe는 여러 submission/completion queue와 MSI-X vector를 사용할 수 있다.
+
+이들을 같은 locality domain에 배치하는 것이 중요하다.
+
+```text
+Application Thread
+    ↓
+Block/NVMe Queue
+    ↓
+MSI-X 처리 CPU
+    ↓
+I/O Buffer Memory
+    ↓
+PCIe NVMe Device
+```
+
+이 구성 요소가 서로 다른 node에 흩어지면 다음 비용이 발생할 수 있다.
+
+- Remote memory access
+- Cache line 이동
+- Interrupt 처리 후 다른 CPU로 작업 전달
+- Inter-socket bandwidth 사용
+- Tail latency 증가
+
+# 12. DMA와 NUMA
+
+Device는 DMA address를 통해 host memory에 접근한다.
+
+DMA 대상 buffer가 device와 가까운 node에 있는지에 따라 data path가 달라질 수 있다.
+
+IOMMU가 address translation을 제공하더라도 물리적인 topology와 interconnect 비용이 사라지는 것은 아니다.
+
+```text
+Address를 접근할 수 있다
+    ≠
+가장 가까운 경로로 접근한다
+```
+
+# 13. NUMA Balancing
+
+OS는 memory access pattern을 관찰해 page를 thread와 가까운 node로 이동시키는 automatic NUMA balancing을 제공할 수 있다.
+
+장기적으로 locality를 개선할 수 있지만 page migration과 sampling 비용이 발생한다.
+
+짧게 실행되는 workload나 thread가 자주 이동하는 workload에서는 안정적인 placement를 만들기 어려울 수 있다.
+
+# 14. NUMA 성능 측정
+
+측정할 때 CPU placement와 memory placement를 독립적으로 제어해야 한다.
+
+```text
+Case 1: CPU Node 0 + Memory Node 0 → Local
+Case 2: CPU Node 0 + Memory Node 1 → Remote
+Case 3: CPU 분산 + Memory Interleave
+```
+
+확인할 지표:
+
+- Load latency
+- Memory bandwidth
+- Local/remote access 비율
+- Cache miss
+- Interconnect traffic
+- Application throughput
+- Average와 tail latency
+
+한 번의 실행 결과보다 workload warm-up, 반복 실행과 분산을 기록해야 한다.
+
+# 15. NUMA 최적화 순서
+
+1. Hardware topology를 확인한다.
+2. Thread와 process의 CPU placement를 확인한다.
+3. Memory page의 placement를 확인한다.
+4. Device와 interrupt의 topology를 확인한다.
+5. Local/remote access와 성능을 측정한다.
+6. CPU affinity와 memory policy를 하나씩 변경한다.
+7. Throughput뿐 아니라 tail latency와 전체 system 영향을 확인한다.
+
+Topology를 확인하지 않고 무조건 thread를 고정하면 scheduler의 load balancing 기회를 잃고 오히려 성능이 나빠질 수 있다.
+
+# 16. 자주 생기는 오해
+
+## 16.1 NUMA에서는 Remote Memory에 접근할 수 없다
+
+접근할 수 있지만 local memory와 비용이 다를 수 있다.
+
+## 16.2 CPU Affinity만 설정하면 NUMA 문제가 해결된다
+
+Memory placement와 device/interrupt locality도 함께 봐야 한다.
+
+## 16.3 모든 Memory를 Interleave하면 항상 빠르다
+
+Bandwidth 분산에는 도움이 될 수 있지만 latency-sensitive workload와 locality에는 불리할 수 있다.
+
+## 16.4 IOMMU가 있으면 Physical Topology는 중요하지 않다
+
+IOMMU는 address translation과 isolation을 제공하지만 node 사이의 물리적 거리와 bandwidth 비용을 없애지 않는다.
+
+## 16.5 NUMA는 Multi-Socket Server에서만 생각하면 된다
+
+엄밀한 topology는 system마다 다르다. OS가 NUMA node로 노출하는 memory와 device locality가 있다면 socket 수만으로 판단하지 않고 실제 topology를 확인해야 한다.
+
+# 정리
+
+NUMA system에서는 memory access 비용이 CPU와 physical memory의 위치에 따라 달라질 수 있다.
+
+```text
+CPU Placement
+  + Memory Placement
+  + Cache Coherence
+  + Device Topology
+  + Interrupt Affinity
+  = 실제 Locality와 성능
+```
+
+Database와 NVMe workload에서는 application thread, I/O queue, interrupt CPU, DMA buffer와 PCIe device의 위치를 하나의 data path로 분석해야 한다.
+
+이제 CPU와 memory의 기본 구조를 바탕으로 atomic operation, cache coherence, memory ordering과 memory barrier를 학습할 수 있다.

--- a/_posts/2026-08-06-virtual-memory-tlb.md
+++ b/_posts/2026-08-06-virtual-memory-tlb.md
@@ -1,0 +1,371 @@
+---
+title: '[Memory] Virtual Memory와 TLB'
+date: 2026-08-06 00:20:00 +09:00
+categories: [computer, memory]
+published: false
+tags:
+  [
+    virtual memory,
+    address translation,
+    page table,
+    TLB,
+    page fault
+  ]
+---
+
+# 개요
+
+Application에서 pointer가 가리키는 주소는 일반적으로 physical memory의 위치가 아니다.
+
+```c
+int value = *pointer;
+```
+
+Process는 virtual address를 사용하고, CPU와 OS는 이를 physical address로 변환한다.
+
+```text
+Virtual Address
+    ↓ Address Translation
+Physical Address
+    ↓ Cache / Memory
+Data
+```
+
+Page table은 변환 관계를 저장하고 TLB는 자주 사용하는 변환 결과를 cache한다.
+
+이 글에서는 virtual memory, page table, page fault와 TLB의 관계를 살펴본다.
+
+# 1. Physical Address만 사용한다면
+
+모든 process가 physical address를 직접 사용한다고 가정해보자.
+
+다음 문제가 발생한다.
+
+- Process가 다른 process의 memory를 쉽게 읽거나 변경할 수 있다.
+- Program이 어느 physical 위치에 배치될지 미리 알아야 한다.
+- 연속된 큰 physical memory를 확보하기 어렵다.
+- 같은 library code를 여러 process가 효율적으로 공유하기 어렵다.
+- Memory보다 큰 address space를 제공하기 어렵다.
+
+Virtual memory는 process가 보는 address space와 실제 physical memory 배치를 분리한다.
+
+# 2. Virtual Address Space
+
+각 process는 자신만의 virtual address space를 가진다.
+
+```text
+Process A Virtual Address 0x1000
+    → Physical Frame 10
+
+Process B Virtual Address 0x1000
+    → Physical Frame 42
+```
+
+두 process가 같은 virtual address를 사용하더라도 서로 다른 physical memory에 mapping될 수 있다.
+
+반대로 shared memory처럼 서로 다른 virtual address가 같은 physical frame을 가리킬 수도 있다.
+
+# 3. Page와 Frame
+
+Virtual memory는 address space를 고정 크기의 page 단위로 관리한다.
+
+Physical memory의 대응 단위를 page frame 또는 physical frame이라고 한다.
+
+```text
+Virtual Pages                     Physical Frames
++---------+                       +---------+
+| Page 0  | --------------------> | Frame 7 |
++---------+                       +---------+
+| Page 1  | -----------+          | Frame 8 |
++---------+            |          +---------+
+| Page 2  | -----+     +--------> | Frame 9 |
++---------+      |                +---------+
+                 +--------------> | Frame 3 |
+                                  +---------+
+```
+
+Virtual address에서 page 내부 offset은 address translation 후에도 유지된다.
+
+```text
+Virtual Address
++---------------------+-------------+
+| Virtual Page Number | Page Offset |
++---------------------+-------------+
+            ↓ translation
+Physical Address
++----------------------+-------------+
+| Physical Frame Number| Page Offset |
++----------------------+-------------+
+```
+
+# 4. Page Table
+
+Page table은 virtual page와 physical frame의 mapping을 저장한다.
+
+Page table entry에는 physical frame 번호 외에도 다음 정보가 포함될 수 있다.
+
+- Present 또는 valid 여부
+- Read/write permission
+- User/kernel permission
+- Executable 여부
+- Accessed 여부
+- Dirty 여부
+- Cache policy 관련 속성
+
+CPU의 memory management unit은 현재 process의 page table을 기준으로 address를 변환하고 permission을 검사한다.
+
+# 5. Multi-Level Page Table
+
+큰 virtual address space의 모든 page에 entry를 미리 만들면 page table 자체가 너무 커진다.
+
+Multi-level page table은 address space를 계층적으로 나누고 실제 사용하는 영역에 필요한 하위 table만 생성한다.
+
+```text
+Virtual Address
+  ├─ Level 1 Index
+  ├─ Level 2 Index
+  ├─ Level 3 Index
+  ├─ Level 4 Index
+  └─ Page Offset
+```
+
+정확한 level 수와 address bit 구성은 architecture와 page size에 따라 다르다.
+
+# 6. Address Translation 과정
+
+TLB miss가 발생했다고 가정하면 load는 개념적으로 다음 과정을 거친다.
+
+```text
+1. CPU가 virtual address 생성
+2. Virtual page number와 offset 분리
+3. Page table walk 수행
+4. Page table entry의 valid와 permission 확인
+5. Physical frame number 획득
+6. Physical address 구성
+7. Cache hierarchy에서 data 검색
+```
+
+매 memory access마다 여러 단계의 page table을 읽으면 큰 비용이 발생한다.
+
+이를 줄이기 위해 TLB를 사용한다.
+
+# 7. TLB
+
+TLB(Translation Lookaside Buffer)는 최근 사용한 virtual page에서 physical frame으로의 변환을 저장하는 cache다.
+
+```text
+Virtual Page Number
+       ↓
+      TLB
+  ├─ Hit  → Physical Frame Number
+  └─ Miss → Page Table Walk
+                ↓
+             TLB에 결과 저장
+```
+
+Cache가 data를 저장한다면 TLB는 address translation 결과를 저장한다.
+
+둘은 서로 다른 역할을 한다.
+
+# 8. TLB Hit와 TLB Miss
+
+## 8.1 TLB Hit
+
+필요한 translation이 TLB에 있으면 page table walk 없이 physical address를 얻을 수 있다.
+
+## 8.2 TLB Miss
+
+Translation이 TLB에 없으면 page table을 조회해야 한다.
+
+Mapping이 유효하다면 page table walk 후 TLB를 채우고 instruction을 계속 실행한다.
+
+TLB miss가 곧 page fault라는 뜻은 아니다.
+
+```text
+TLB Miss
+  → Page Table Entry Valid
+      → Translation을 TLB에 채움
+
+TLB Miss
+  → Page Table Entry Invalid 또는 특별한 처리 필요
+      → Page Fault
+```
+
+# 9. Page Fault
+
+CPU가 현재 page table mapping으로 처리할 수 없는 memory access를 만나면 exception을 발생시킨다.
+
+OS의 page fault handler가 원인을 확인한다.
+
+## 9.1 Demand Paging
+
+Virtual address space는 예약되어 있지만 physical page가 아직 할당되지 않은 경우다.
+
+OS가 physical frame을 할당하고 page table을 갱신한 뒤 instruction을 다시 실행할 수 있다.
+
+## 9.2 File-Backed Page
+
+Executable, shared library 또는 memory-mapped file의 page가 아직 memory에 없을 수 있다.
+
+OS가 storage에서 page를 읽어온다.
+
+## 9.3 Copy-on-Write
+
+여러 process가 read-only로 공유하던 page를 한 process가 수정하려 할 수 있다.
+
+OS가 새 physical page를 만들고 내용을 복사한 뒤 해당 process의 mapping을 변경한다.
+
+## 9.4 Invalid Access
+
+Mapping되지 않은 주소 또는 permission을 위반한 접근이라면 OS가 process에 segmentation fault 같은 오류를 전달할 수 있다.
+
+# 10. Minor Fault와 Major Fault
+
+일반적인 OS 통계에서는 page fault를 다음처럼 구분할 수 있다.
+
+- Minor fault: 필요한 page가 memory에 있어 storage I/O 없이 mapping을 구성할 수 있음
+- Major fault: 필요한 page를 storage에서 읽어야 함
+
+Major fault는 storage latency를 포함할 수 있어 훨씬 큰 비용이 발생한다.
+
+하지만 정확한 분류와 명칭은 OS 구현과 관찰 도구의 정의를 확인해야 한다.
+
+# 11. Page Size와 TLB Reach
+
+TLB가 cover할 수 있는 memory 범위를 TLB reach라고 생각할 수 있다.
+
+```text
+TLB Reach ≈ TLB Entry 수 × Page Size
+```
+
+예를 들어 같은 TLB entry 수에서 page size가 크면 더 넓은 memory 영역의 translation을 저장할 수 있다.
+
+큰 working set을 random하게 접근하면 TLB entry가 자주 교체되어 TLB miss가 증가할 수 있다.
+
+# 12. Huge Page
+
+일반 page보다 큰 page를 사용하면 같은 memory 범위에 필요한 TLB entry 수를 줄일 수 있다.
+
+장점:
+
+- TLB miss 감소 가능
+- Page table 크기와 walk 횟수 감소 가능
+
+비용과 주의점:
+
+- 작은 object에 사용하면 internal fragmentation 증가
+- 큰 연속 physical memory 확보가 어려울 수 있음
+- Allocation과 compaction 비용 발생 가능
+- NUMA placement가 잘못되면 더 큰 범위가 잘못된 node에 배치될 수 있음
+- 모든 workload에서 성능이 향상되는 것은 아님
+
+# 13. Context Switch와 TLB
+
+Process가 바뀌면 같은 virtual address가 다른 physical frame을 의미할 수 있다.
+
+따라서 TLB entry가 어느 address space의 translation인지 구분해야 한다.
+
+Architecture는 address-space identifier 같은 tag를 사용해 여러 process의 entry를 구분할 수 있다.
+
+그렇지 않거나 mapping이 변경된 경우 TLB entry를 invalidate해야 한다.
+
+# 14. TLB Shootdown
+
+한 process의 page table을 여러 CPU core가 사용하고 있을 때 mapping을 변경하면 다른 core의 오래된 TLB entry도 무효화해야 한다.
+
+```text
+Core A가 Page Table 변경
+  → Core B와 Core C에 invalidate 요청
+  → 각 Core가 해당 TLB entry 제거
+  → 완료 동기화
+```
+
+이 과정을 TLB shootdown이라고 한다.
+
+Memory mapping을 자주 변경하는 workload에서는 core 간 coordination 비용이 발생할 수 있다.
+
+# 15. Cache와 TLB의 관계
+
+CPU가 cache를 검색하려면 address의 일부 또는 전체가 필요하다.
+
+Address translation과 cache lookup을 어떤 순서와 방식으로 겹치는지는 cache 설계에 따라 다르다.
+
+Software 관점에서는 다음 두 working set을 구분하는 것이 중요하다.
+
+- Cache working set: 자주 사용하는 data의 cache line 집합
+- TLB working set: 자주 사용하는 virtual page의 translation 집합
+
+Data가 cache에 잘 맞더라도 많은 page에 흩어져 있으면 TLB miss가 발생할 수 있다.
+
+# 16. Device I/O와 Virtual Memory
+
+Application은 virtual address의 buffer를 사용하지만 device가 process의 일반 virtual address를 그대로 이해하는 것은 아니다.
+
+Driver와 OS는 buffer를 DMA에 사용할 수 있도록 mapping하고 device-visible address를 준비한다.
+
+```text
+Application Virtual Address
+    ↓ OS가 page 확인 및 고정
+Physical Pages
+    ↓ DMA Mapping / IOMMU
+Device-visible DMA Address
+```
+
+IOMMU는 device의 DMA address를 physical memory로 translation하고 접근 권한을 제한할 수 있다.
+
+CPU의 page table과 IOMMU의 translation table은 목적과 사용 주체가 다르다.
+
+# 17. 성능을 분석할 때 확인할 것
+
+- Working set의 전체 크기
+- 접근하는 page 수
+- Page size
+- Sequential 또는 random access
+- Page fault 수
+- Minor/major fault 구분
+- TLB miss
+- Page table walk 비용
+- Memory mapping 변경 빈도
+- TLB shootdown
+- NUMA placement
+
+# 18. 자주 생기는 오해
+
+## 18.1 Virtual Memory는 Memory보다 큰 공간을 쓰기 위한 기능뿐이다
+
+Virtual memory는 isolation, permission, flexible placement와 sharing도 제공한다.
+
+## 18.2 TLB Miss는 Page Fault다
+
+Page table에 valid mapping이 있다면 TLB만 채우고 계속 실행할 수 있다.
+
+## 18.3 Page Fault는 항상 오류다
+
+Demand paging과 copy-on-write를 처리하기 위한 정상적인 page fault도 있다.
+
+## 18.4 Virtual Address와 Physical Address는 항상 일대일이다
+
+서로 다른 virtual page가 같은 physical frame을 공유할 수 있고, mapping은 시간에 따라 변경될 수 있다.
+
+## 18.5 Huge Page는 항상 빠르다
+
+TLB miss를 줄일 수 있지만 memory 낭비, allocation, NUMA와 workload 특성을 함께 고려해야 한다.
+
+# 정리
+
+Virtual memory는 process의 address space와 physical memory 배치를 분리한다.
+
+Page table은 virtual page를 physical frame에 mapping하고 permission을 관리한다.
+
+TLB는 자주 사용하는 address translation을 cache해 page table walk 비용을 줄인다.
+
+```text
+Virtual Address
+  → TLB
+      ├─ Hit  → Physical Address
+      └─ Miss → Page Table Walk
+                    ├─ Valid → TLB Fill
+                    └─ 처리 필요 → Page Fault
+```
+
+다음 글에서는 memory에 저장된 여러 byte를 어떤 순서로 해석하는지, data가 특정 address 경계에 배치되는 이유를 살펴본다.


### PR DESCRIPTION
## What changed

- Added the fourth C atomic operation post about memory ordering.
- Explained sequenced-before, reads-from, synchronizes-with, and happens-before.
- Covered relaxed, release/acquire publication, compare-exchange orderings, and sequential consistency.
- Added hardware-oriented explanations for store buffers and cache coherence.

## Why

The post continues the C atomic operation series and connects the earlier CPU-level discussion to the C memory model with detailed examples and diagrams.

## Validation

- `bundle exec jekyll build`
- `git diff --cached --check`
